### PR TITLE
Fix `CMakeLists` for cross-compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,9 +59,6 @@ if(CROSS_COMPILE)
 	add_definitions(-DUSE_CLANG_OPENCL=1)
 endif()
 
-message(STATUS ${CMAKE_C_COMPILER})
-message(STATUS ${CMAKE_CXX_COMPILER})
-
 project (VC4C VERSION 0.4)
 add_definitions(-DVC4C_VERSION="${PROJECT_VERSION}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,13 +47,20 @@ if(CROSS_COMPILE)
 	SET(CMAKE_C_COMPILER   		"${CROSS_COMPILER_PATH}/bin/arm-linux-gnueabihf-gcc")
 	SET(CMAKE_CXX_COMPILER 		"${CROSS_COMPILER_PATH}/bin/arm-linux-gnueabihf-g++")
 	SET(CMAKE_FIND_ROOT_PATH  	"${CROSS_COMPILER_PATH} ${CROSS_COMPILER_PATH}/arm-linux-gnueabihf")
-
+        SET(CMAKE_AR                    "${CROSS_COMPILER_PATH}/bin/arm-linux-gnueabihf-ar")
+        SET(CMAKE_CXX_COMPILER_AR       "${CROSS_COMPILER_PATH}/bin/arm-linux-gnueabihf-gcc-ar")
+        SET(CMAKE_CXX_COMPILER_RANLIB   "${CROSS_COMPILER_PATH}/bin/arm-linux-gnueabihf-ranlib")
+        SET(CMAKE_C_COMPILER_AR         "${CROSS_COMPILER_PATH}/bin/arm-linux-gnueabihf-gcc-ar")
+        SET(CMAKE_CXX_COMPILER_RANLIB   "${CROSS_COMPILER_PATH}/bin/arm-linux-gnueabihf-ranlib")
+        SET(CMAKE_LINKER                "${CROSS_COMPILER_PATH}/bin/arm-linux-gnueabihf-ld")
 	# Raspbian ships CLang 3.9 in its repositories
 	add_definitions(-DCLANG_PATH="/usr/bin/clang-3.9")
 	set(CLANG_FOUND ON)
 	add_definitions(-DUSE_CLANG_OPENCL=1)
 endif()
 
+message(STATUS ${CMAKE_C_COMPILER})
+message(STATUS ${CMAKE_CXX_COMPILER})
 
 project (VC4C VERSION 0.4)
 add_definitions(-DVC4C_VERSION="${PROJECT_VERSION}")
@@ -100,6 +107,10 @@ ExternalProject_Add( cpplog-project
 	STEP_TARGETS 		build	#If we set our dependency on this, the install step is skipped
   	EXCLUDE_FROM_ALL 	TRUE	#Skip for "make all" to skip install
   	TIMEOUT 			30		#Timeout for downloads, in seconds
+        CMAKE_ARGS
+          -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+	  -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+	  -DCMAKE_FIND_ROOT_PATH=${CMAKE_FIND_ROOT_PATH}
 )
 
 # Prefer Khronos OpenCL to LLVM IR (to SPIR-V) compiler
@@ -153,6 +164,10 @@ if(SPIRV_LLVM_SPIR_FOUND AND SPIRV_FRONTEND)
 		STEP_TARGETS 		build
   		EXCLUDE_FROM_ALL	TRUE
   		TIMEOUT 			30		#Timeout for downloads, in seconds
+                CMAKE_ARGS
+                  -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+                  -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+                  -DCMAKE_FIND_ROOT_PATH=${CMAKE_FIND_ROOT_PATH}
 	)
 	# skip executables and tests for the SPIR-V parser
 	ExternalProject_Add(spirv-tools-project
@@ -165,6 +180,10 @@ if(SPIRV_LLVM_SPIR_FOUND AND SPIRV_FRONTEND)
 		STEP_TARGETS 		build
   		EXCLUDE_FROM_ALL	TRUE
   		TIMEOUT 			30		#Timeout for downloads, in seconds
+                CMAKE_ARGS
+                  -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+                  -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+                  -DCMAKE_FIND_ROOT_PATH=${CMAKE_FIND_ROOT_PATH}
 	)
 	add_definitions(-DSPIRV_LLVM_SPIRV_PATH="${SPIRV_LLVM_SPIR_FOUND}")
 	add_definitions(-DSPIRV_HEADER="${PROJECT_SOURCE_DIR}/lib/spirv-headers/include/spirv/1.2/spirv.h")
@@ -184,6 +203,10 @@ if(VERIFY_OUTPUT)
 		STEP_TARGETS 		build
   		EXCLUDE_FROM_ALL	TRUE
   		TIMEOUT 			30		#Timeout for downloads, in seconds
+                CMAKE_ARGS
+                  -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+                  -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+                  -DCMAKE_FIND_ROOT_PATH=${CMAKE_FIND_ROOT_PATH}
 	)
 
 	add_definitions(-DVERIFIER_HEADER="${PROJECT_SOURCE_DIR}/lib/vc4asm/src/Validator.h")
@@ -220,6 +243,10 @@ if (BUILD_TESTING)
 		STEP_TARGETS 		build
   		EXCLUDE_FROM_ALL	TRUE
   		TIMEOUT 			30		#Timeout for downloads, in seconds
+                CMAKE_ARGS
+                  -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+                  -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+                  -DCMAKE_FIND_ROOT_PATH=${CMAKE_FIND_ROOT_PATH}
 	)
     add_subdirectory(test build/test)
-endif (BUILD_TESTING) 
+endif (BUILD_TESTING)


### PR DESCRIPTION
I fixed `CMakeLists.txt` to pass cross-compilation config for external projects.
Before applying my patch, compilation failed during linking because external projects were compiled by a host compiler.
My patch just fix to pass such paths correctly.