### PR TITLE
Surpress make fusion of add & mul

### DIFF
--- a/src/Precompiler.cpp
+++ b/src/Precompiler.cpp
@@ -186,6 +186,8 @@ static std::string buildCommand(const std::string& compiler, const std::string& 
 		command.append("-O3 ");
 	}
 
+	command.append("-ffp-contract=off ");
+
 #if defined USE_CLANG_OPENCL || defined SPIRV_CLANG_PATH
 	if(options.find("-cl-std") == std::string::npos)
 	{


### PR DESCRIPTION
This patch surpress fusion of add & mul in `clang`. 
In `vc4`, `fmuladd` cannot be translated effectively (see #17). 