### PR TITLE
Use a new docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: nomaddo/cross-rpi
+      - image: nomaddo/cross-rpi:0.1
     steps:
       - checkout
       - run:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,20 +42,20 @@ endif()
 
 if(CROSS_COMPILE)
 	if(NOT CROSS_COMPILER_PATH)
-		set(CROSS_COMPILER_PATH "/opt/raspberrypi/tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64")
+		set(CROSS_COMPILER_PATH "/usr/bin")
 	endif()
 	message(STATUS "Cross compiling for Raspbian with compiler: ${CROSS_COMPILER_PATH}")
 	#Set Cross compiler
-	SET(CMAKE_SYSTEM_NAME 		    "Linux")
-	SET(CMAKE_C_COMPILER   		    "${CROSS_COMPILER_PATH}/bin/arm-linux-gnueabihf-gcc")
-	SET(CMAKE_CXX_COMPILER 		    "${CROSS_COMPILER_PATH}/bin/arm-linux-gnueabihf-g++")
-	SET(CMAKE_FIND_ROOT_PATH  	    "${CROSS_COMPILER_PATH}/arm-linux-gnueabihf")
-	SET(CMAKE_AR                    "${CROSS_COMPILER_PATH}/bin/arm-linux-gnueabihf-ar")
-	SET(CMAKE_CXX_COMPILER_AR       "${CROSS_COMPILER_PATH}/bin/arm-linux-gnueabihf-gcc-ar")
-	SET(CMAKE_CXX_COMPILER_RANLIB   "${CROSS_COMPILER_PATH}/bin/arm-linux-gnueabihf-ranlib")
-	SET(CMAKE_C_COMPILER_AR         "${CROSS_COMPILER_PATH}/bin/arm-linux-gnueabihf-gcc-ar")
-	SET(CMAKE_CXX_COMPILER_RANLIB   "${CROSS_COMPILER_PATH}/bin/arm-linux-gnueabihf-ranlib")
-	SET(CMAKE_LINKER                "${CROSS_COMPILER_PATH}/bin/arm-linux-gnueabihf-ld")
+	SET(CMAKE_SYSTEM_NAME 		"Linux")
+	SET(CMAKE_C_COMPILER   		"${CROSS_COMPILER_PATH}/arm-linux-gnueabihf-gcc")
+	SET(CMAKE_CXX_COMPILER 		"${CROSS_COMPILER_PATH}/arm-linux-gnueabihf-g++")
+	SET(CMAKE_FIND_ROOT_PATH  	"${CROSS_COMPILER_PATH}/../../")
+	SET(CMAKE_AR                    "${CROSS_COMPILER_PATH}/arm-linux-gnueabihf-ar")
+	SET(CMAKE_CXX_COMPILER_AR       "${CROSS_COMPILER_PATH}/arm-linux-gnueabihf-gcc-ar")
+	SET(CMAKE_CXX_COMPILER_RANLIB   "${CROSS_COMPILER_PATH}/arm-linux-gnueabihf-ranlib")
+	SET(CMAKE_C_COMPILER_AR         "${CROSS_COMPILER_PATH}/arm-linux-gnueabihf-gcc-ar")
+	SET(CMAKE_CXX_COMPILER_RANLIB   "${CROSS_COMPILER_PATH}/arm-linux-gnueabihf-ranlib")
+	SET(CMAKE_LINKER                "${CROSS_COMPILER_PATH}/arm-linux-gnueabihf-ld")
 	# Raspbian ships CLang 3.9 in its repositories
 	set(CLANG_FOUND /usr/bin/clang-3.9)
 	add_definitions(-DCLANG_PATH="${CLANG_FOUND}")
@@ -223,7 +223,7 @@ if(LLVMLIB_FRONTEND)
 			# So for shared linking, clear system libraries
 			set(LLVM_SYSTEM_LIB_NAMES "")
 		endif()
-		
+
 		#Depending on the LLVM library version used, we need to use some other functions/headers in the LLVM library front-end
 		if(LLVM_LIB_VERSION)
 			string(REPLACE "." ";" LLVM_VERSION_ELEMENTS ${LLVM_LIB_VERSION})
@@ -233,7 +233,7 @@ if(LLVMLIB_FRONTEND)
 		else()
 			message(WARNING "Failed to determine LLVM library version")
 		endif()
-		
+
 		if(LLVM_LIBS_PATH AND LLVM_INCLUDE_PATH AND LLVM_LIB_FLAGS AND LLVM_LIB_NAMES)
 			# For cross-compilation, we need to link against the correct (compiled for the target architecture) libLLVM.
 			# Since llvm-config does not heed CMAKE_FIND_ROOT_PATH, we need to manually set it
@@ -257,7 +257,7 @@ if(LLVMLIB_FRONTEND)
 endif()
 
 if(NOT ((SPIRV_LLVM_SPIR_FOUND AND SPIRV_FRONTEND) OR (LLVMLIB_FRONTEND AND LLVM_LIBS_PATH)))
-	message(WARNUNG "Neither SPIR-V nor LLVM library front-end are configured. Falling back to very slow and no longer maintained LLVM IR front-end!")
+	message(WARNUNG " Neither SPIR-V nor LLVM library front-end are configured. Falling back to very slow and no longer maintained LLVM IR front-end!")
 endif()
 
 if(VERIFY_OUTPUT)


### PR DESCRIPTION
This pullreq change docker image we use, and change default settings of cmake to adapt it (discussed in https://github.com/doe300/VC4CL/issues/17#issuecomment-367316084).
The new docker images is tagged as `0.1` like `nomaddo/cross-rpi:0.1`.
See https://github.com/nomaddo/cross-rpi/commit/c782d74b3eae6d4eda347f5a111fd457ac56c7cc

In current status, build succeed but fail to find llvm libraries.
I am not sure about setting of llvm (around Line 221 to 257 in `CMakeLists.txt`).
@doe300 Can you change it?