### PR TITLE
Make asm output verbose (add information of labels)

### DIFF
--- a/src/asm/ALUInstruction.cpp
+++ b/src/asm/ALUInstruction.cpp
@@ -113,17 +113,19 @@ std::string ALUInstruction::toASMString() const
     	// -> vector rotation
     	mulPart.append(" ").append(static_cast<SmallImmediate>(getInputB()).to_string());
     }
+	std::string s;
     if(opAdd != OP_NOP)
     {
         if(opMul != OP_NOP)
-        {
-            return (addPart + "; ") + mulPart;
-        }
-        return addPart;
-    }
-    if(opMul != OP_NOP)
-        return mulPart;
-    return addPart;
+			s = (addPart + "; ") + mulPart;
+		else
+			s = addPart;
+    } else if(opMul != OP_NOP)
+        s = mulPart;
+	else
+		s = addPart;
+
+	return addComment(s);
 }
 
 bool ALUInstruction::isValidInstruction() const
@@ -137,3 +139,4 @@ bool ALUInstruction::isValidInstruction() const
 			return true;
 	}
 }
+

--- a/src/asm/ALUInstruction.h
+++ b/src/asm/ALUInstruction.h
@@ -15,7 +15,6 @@ namespace vc4c
 
 	namespace qpu_asm
 	{
-
 		class ALUInstruction : public Instruction
 		{
 		public:

--- a/src/asm/BranchInstruction.cpp
+++ b/src/asm/BranchInstruction.cpp
@@ -26,13 +26,14 @@ BranchInstruction::BranchInstruction(const BranchCond cond, const BranchRel rela
 
 std::string BranchInstruction::toASMString() const
 {
-    return std::string("br") + (getBranchRelative() == BranchRel::BRANCH_RELATIVE ? "r" : "a") + 
+    auto s =std::string("br") + (getBranchRelative() == BranchRel::BRANCH_RELATIVE ? "r" : "a") +
             ((getBranchCondition() == BranchCond::ALWAYS ? "" : std::string(".") + toString(getBranchCondition())) + " ") +
             (getAddOut() != REG_NOP.num ? Register{RegisterFile::PHYSICAL_A, getAddOut()}.to_string(true, false) + ", " : "") +
             (getMulOut() != REG_NOP.num ? Register{RegisterFile::PHYSICAL_B, getMulOut()}.to_string(true, false) + ", " : "") +
 			(getBranchRelative() == BranchRel::BRANCH_RELATIVE ? "(pc+4) + " : "") +
             std::to_string(getImmediate() / 8 /* byte-index -> instruction-index */) +
             (getAddRegister() == BranchReg::BRANCH_REG ? std::string(" + ") + Register{RegisterFile::PHYSICAL_A, getRegisterAddress()}.to_string(true, true) : "");
+    return addComment(s);
 }
 
 bool BranchInstruction::isValidInstruction() const

--- a/src/asm/CodeGenerator.cpp
+++ b/src/asm/CodeGenerator.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Author: doe300
  *
  * See the file "LICENSE" for the full license governing this code.
@@ -38,8 +38,8 @@ static FastMap<const Local*, std::size_t> mapLabels(Method& method)
 		{
 			logging::debug() << "Mapping label '" << label->getLabel()->name << "' to byte-position " << index << logging::endl;
 			labelsMap[label->getLabel()] = index;
-			//we do not need the position of the label at all anymore
-			it.erase();
+
+			it.nextInMethod();
 		}
 		else if(!it.isEndOfBlock() && it.has() && !it->mapsToASMInstruction())
 		{
@@ -88,7 +88,7 @@ const FastModificationList<std::unique_ptr<qpu_asm::Instruction>>& CodeGenerator
 		logging::warn() << "Register conflict resolver has exceeded its maximum rounds, there might still be errors!" << logging::endl;
 	}
 	PROFILE_END(colorGraph);
-    
+
     //create label-map + remove labels
     const auto labelMap = mapLabels(method);
 
@@ -104,14 +104,23 @@ const FastModificationList<std::unique_ptr<qpu_asm::Instruction>>& CodeGenerator
 
     logging::debug() << "-----" << logging::endl;
     std::size_t index = 0;
-    method.forAllInstructions([&generatedInstructions, &index, &registerMapping, &labelMap](const IntermediateInstruction* instr) -> bool
+
+	IntermediateInstruction* previous = nullptr;
+    method.forAllInstructions([&generatedInstructions, &index, &registerMapping, &labelMap, &previous](const IntermediateInstruction* instr) -> bool
 	{
-    	Instruction* mapped = instr->convertToAsm(registerMapping, labelMap, index);
-		if (mapped != nullptr) {
-			generatedInstructions.emplace_back(mapped);
+		if (instr->mapsToASMInstruction()) {
+			Instruction *mapped = instr->convertToAsm(registerMapping, labelMap, index);
+			if (auto label = dynamic_cast<BranchLabel*>(previous))
+				mapped->comment += label->getLabel()->to_string();
+			if (mapped != nullptr) {
+				generatedInstructions.emplace_back(mapped);
+			}
+			++index;
 		}
-		++index;
+
+		previous = const_cast<IntermediateInstruction*>(instr);
 		return true;
+		// XXX: use const_cast because `forAllInstructions` is only defined for `bool(const IntermediateInstruction*)`
 	});
 
     logging::debug() << "-----" << logging::endl;

--- a/src/asm/CommentInstruction.cpp
+++ b/src/asm/CommentInstruction.cpp
@@ -1,0 +1,21 @@
+/*
+ * Author: nomaddo
+ *
+ * See the file "LICENSE" for the full license governing this code.
+ */
+
+#include "CommentInstruction.h"
+
+vc4c::qpu_asm::Comment::Comment(std::string s) : Instruction(0x000000) {
+	comment = s;
+}
+
+std::string vc4c::qpu_asm::Comment::toASMString() const {
+	return addComment("");
+}
+
+bool vc4c::qpu_asm::Comment::isValidInstruction() const {
+	return true;
+}
+
+

--- a/src/asm/CommentInstruction.h
+++ b/src/asm/CommentInstruction.h
@@ -1,0 +1,27 @@
+/*
+ * Author: nomaddo
+ *
+ * See the file "LICENSE" for the full license governing this code.
+ */
+
+// comment instruction for debugging its output
+
+#ifndef VC4C_COMMENTINSTRUCTION_H
+#define VC4C_COMMENTINSTRUCTION_H
+
+#include "Instruction.h"
+
+namespace vc4c {
+namespace qpu_asm {
+class Comment : public Instruction {
+public:
+	explicit Comment(std::string);
+	~Comment() override = default;
+
+	std::string toASMString() const override;
+	bool isValidInstruction() const override;
+};
+}
+}
+
+#endif //VC4C_COMMENTINSTRUCTION_H

--- a/src/asm/Instruction.cpp
+++ b/src/asm/Instruction.cpp
@@ -125,6 +125,13 @@ std::string Instruction::toExtrasString(const Signaling sig, const ConditionCode
     return result;
 }
 
+std::string Instruction::addComment(std::string s) const {
+	if (comment == "")
+		return s;
+	else
+		return s + " // " + comment;
+}
+
 std::string qpu_asm::toHexString(const uint64_t code)
 {
 	//lower half before upper half

--- a/src/asm/Instruction.h
+++ b/src/asm/Instruction.h
@@ -27,7 +27,6 @@ namespace vc4c
 		class Instruction : protected Bitfield<uint64_t>
 		{
 		public:
-
 			Instruction();
 			explicit Instruction(uint64_t code);
 			virtual ~Instruction();
@@ -55,7 +54,8 @@ namespace vc4c
 			BITFIELD_ENTRY(WriteSwap, WriteSwap, 44, Bit)
 			BITFIELD_ENTRY(AddOut, Address, 38, Sextuple)
 			BITFIELD_ENTRY(MulOut, Address, 32, Sextuple)
-
+			std::string comment;
+			std::string addComment(std::string s) const;
 		protected:
 
 			static std::string toInputRegister(InputMultiplex mux, Address regA, Address regB, bool hasImmediate = false);

--- a/src/asm/Instruction.h
+++ b/src/asm/Instruction.h
@@ -54,7 +54,11 @@ namespace vc4c
 			BITFIELD_ENTRY(WriteSwap, WriteSwap, 44, Bit)
 			BITFIELD_ENTRY(AddOut, Address, 38, Sextuple)
 			BITFIELD_ENTRY(MulOut, Address, 32, Sextuple)
-			std::string comment;
+
+			/*
+			 * Comment to debug output with `--asm`
+			 */
+			std::string comment = "";
 			std::string addComment(std::string s) const;
 		protected:
 

--- a/src/asm/LoadInstruction.cpp
+++ b/src/asm/LoadInstruction.cpp
@@ -62,13 +62,15 @@ std::string LoadInstruction::toASMString() const
 {
 	if(getEntry<uint8_t>(57, MASK_Septuple) == static_cast<uint8_t>(OpLoad::LOAD_SIGNED))
 	{
-		return std::string("ldi") + (toExtrasString(SIGNAL_NONE, getAddCondition(), getSetFlag()) + " ") +
+		auto s = std::string("ldi") + (toExtrasString(SIGNAL_NONE, getAddCondition(), getSetFlag()) + " ") +
 		            ((toOutputRegister(getWriteSwap() == WriteSwap::DONT_SWAP, getAddOut()) + ", ") + std::to_string(getImmediateSignedShort0()) + ", ") + std::to_string(getImmediateSignedShort1());
+		return addComment(s);
 	}
 	if(getEntry<uint8_t>(57, MASK_Septuple) == static_cast<uint8_t>(OpLoad::LOAD_UNSIGNED))
 	{
-		return std::string("ldi") + (toExtrasString(SIGNAL_NONE, getAddCondition(), getSetFlag()) + " ") +
-				            ((toOutputRegister(getWriteSwap() == WriteSwap::DONT_SWAP, getAddOut()) + ", ") + std::to_string(getImmediateShort0()) + ", ") + std::to_string(getImmediateShort1());
+		auto s = std::string("ldi") + (toExtrasString(SIGNAL_NONE, getAddCondition(), getSetFlag()) + " ") +
+				 ((toOutputRegister(getWriteSwap() == WriteSwap::DONT_SWAP, getAddOut()) + ", ") + std::to_string(getImmediateShort0()) + ", ") + std::to_string(getImmediateShort1());
+		return addComment(s);
 	}
 	std::string valString;
 	if(getAddOut() == REG_VPM_OUT_SETUP.num)
@@ -82,8 +84,9 @@ std::string LoadInstruction::toASMString() const
 	}
 	else
 		valString = std::to_string(getImmediateInt());
-    return std::string("ldi") + (toExtrasString(SIGNAL_NONE, getAddCondition(), getSetFlag()) + " ") +
-            (toOutputRegister(getWriteSwap() == WriteSwap::DONT_SWAP, getAddOut()) + ", ") + valString;
+    auto s = std::string("ldi") + (toExtrasString(SIGNAL_NONE, getAddCondition(), getSetFlag()) + " ") +
+			 (toOutputRegister(getWriteSwap() == WriteSwap::DONT_SWAP, getAddOut()) + ", ") + valString;
+	return addComment(s);
 }
 
 bool LoadInstruction::isValidInstruction() const

--- a/src/asm/SemaphoreInstruction.cpp
+++ b/src/asm/SemaphoreInstruction.cpp
@@ -27,10 +27,14 @@ SemaphoreInstruction::SemaphoreInstruction(const Pack pack, const ConditionCode 
 
 std::string SemaphoreInstruction::toASMString() const
 {
+    std::string s;
     std::string result(toExtrasString(SIGNAL_NONE, getAddCondition(), getSetFlag(), UNPACK_NOP, getPack()));
     if(getIncrementSemaphore())
-        return std::string("sacq") + (result + " ") + (toOutputRegister(getWriteSwap() == WriteSwap::DONT_SWAP, getAddOut()) + ", ") + std::to_string(static_cast<unsigned char>(getSemaphore()));
-    return std::string("srel") + (result + " ") + (toOutputRegister(getWriteSwap() == WriteSwap::DONT_SWAP, getAddOut()) + ", ") + std::to_string(static_cast<unsigned char>(getSemaphore()));
+        s = std::string("sacq") + (result + " ") + (toOutputRegister(getWriteSwap() == WriteSwap::DONT_SWAP, getAddOut()) + ", ") + std::to_string(static_cast<unsigned char>(getSemaphore()));
+    else
+        s = std::string("srel") + (result + " ") + (toOutputRegister(getWriteSwap() == WriteSwap::DONT_SWAP, getAddOut()) + ", ") + std::to_string(static_cast<unsigned char>(getSemaphore()));
+
+    return addComment(s);
 }
 
 bool SemaphoreInstruction::isValidInstruction() const

--- a/src/intermediate/Branching.cpp
+++ b/src/intermediate/Branching.cpp
@@ -88,7 +88,9 @@ qpu_asm::Instruction* Branch::convertToAsm(const FastMap<const Local*, Register>
 		cond = conditional.toBranchCondition();
 	if(branchOffset < static_cast<int64_t>(std::numeric_limits<int32_t>::min()) || branchOffset > static_cast<int64_t>(std::numeric_limits<int32_t>::max()))
 		throw CompilationError(CompilationStep::CODE_GENERATION, "Cannot jump a distance not fitting into 32-bit integer", std::to_string(branchOffset));
-    return new qpu_asm::BranchInstruction(cond, BranchRel::BRANCH_RELATIVE, BranchReg::NONE, 0 /* only 5 bits, so REG_NOP doesn't fit */, REG_NOP.num, REG_NOP.num, static_cast<int32_t>(branchOffset));
+    auto qasm = new qpu_asm::BranchInstruction(cond, BranchRel::BRANCH_RELATIVE, BranchReg::NONE, 0 /* only 5 bits, so REG_NOP doesn't fit */, REG_NOP.num, REG_NOP.num, static_cast<int32_t>(branchOffset));
+	qasm->comment = this->getTarget()->name;
+	return qasm;
 }
 
 const Local* Branch::getTarget() const

--- a/src/intermediate/Branching.cpp
+++ b/src/intermediate/Branching.cpp
@@ -7,6 +7,7 @@
 #include "IntermediateInstruction.h"
 #include "../asm/BranchInstruction.h"
 #include "log.h"
+#include "../asm/CommentInstruction.h"
 
 using namespace vc4c;
 using namespace vc4c::intermediate;
@@ -28,12 +29,12 @@ IntermediateInstruction* BranchLabel::copyFor(Method& method, const std::string&
 
 qpu_asm::Instruction* BranchLabel::convertToAsm(const FastMap<const Local*, Register>& registerMapping, const FastMap<const Local*, std::size_t>& labelMapping, const std::size_t instructionIndex) const
 {
-    throw CompilationError(CompilationStep::CODE_GENERATION, "There should be no more labels at this point", to_string());
+	return new qpu_asm::Comment(getLabel()->to_string(true));
 }
 
 bool BranchLabel::mapsToASMInstruction() const
 {
-	return false;
+	return true;
 }
 
 const Local* BranchLabel::getLabel() const
@@ -89,7 +90,7 @@ qpu_asm::Instruction* Branch::convertToAsm(const FastMap<const Local*, Register>
 	if(branchOffset < static_cast<int64_t>(std::numeric_limits<int32_t>::min()) || branchOffset > static_cast<int64_t>(std::numeric_limits<int32_t>::max()))
 		throw CompilationError(CompilationStep::CODE_GENERATION, "Cannot jump a distance not fitting into 32-bit integer", std::to_string(branchOffset));
     auto qasm = new qpu_asm::BranchInstruction(cond, BranchRel::BRANCH_RELATIVE, BranchReg::NONE, 0 /* only 5 bits, so REG_NOP doesn't fit */, REG_NOP.num, REG_NOP.num, static_cast<int32_t>(branchOffset));
-	qasm->comment = this->getTarget()->name;
+	qasm->comment = "to " + this->getTarget()->to_string();
 	return qasm;
 }
 

--- a/src/intermediate/Branching.cpp
+++ b/src/intermediate/Branching.cpp
@@ -34,7 +34,7 @@ qpu_asm::Instruction* BranchLabel::convertToAsm(const FastMap<const Local*, Regi
 
 bool BranchLabel::mapsToASMInstruction() const
 {
-	return true;
+	return false;
 }
 
 const Local* BranchLabel::getLabel() const


### PR DESCRIPTION
This pullreq add label information to the output.
You see, labels like `// label %16` in jump instructions and the beginning of each basic_blocks.

```c
kernel void loop1 (global float * a) {
  int id = get_global_id(0);
  a[id] = a[id] + 1;
}
```

```asm
// Module with 1 kernels, global data with 0 words (64-bit each), starting at offset 1 words and 0 words of stack-frame
// Kernel 'loop1' with 46 instructions, offset 2, with following parameters: __global out float* a (4 B, 1 items)
or -, unif, unif // label %start_of_function
or r1, unif, unif
or ra2, unif, unif
or -, unif, unif
or -, unif, unif
or -, unif, unif
or r0, unif, unif
or -, unif, unif
or -, unif, unif
or r2, unif, unif
or -, unif, unif
or -, unif, unif
or -, unif, unif
or ra0, unif, unif
or ra1, r0, r0; v8min r0, r1, r1 // label %16
ldi r1, 255
and r3, r0, r1
or r2, r2, r2; v8min r0, ra2, ra2
and r1, r0, r1
mul24 r0, ra1, r3
add r0, r2, r0
add r0, r0, r1
shl r0, r0, 2 (2)
add r1, ra0, r0
nop.never 
or tmu0s, r1, r1
nop.load_tmu0.never 
or r0, r4, r4
or -, mutex_acq, mutex_acq
ldi vpw_setup, vpm_setup(size: 16 words, stride: 1 rows, address: h32(0))
fadd vpm, r0, 1.000000 (32)
ldi vpw_setup, vdw_setup(rows: 1, elements: 1 words, address: h32(0))
ldi vpw_setup, vdw_setup(stride: 0)
or vpw_addr, r1, r1
or -, vpw_wait, vpw_wait
or mutex_rel, 1 (1), 1 (1)
or r0, unif, unif // label %end_of_function
or.setf -, elem_num, r0
brr.ifallzc (pc+4) + -42 // %start_of_function
nop.never 
nop.never 
nop.never 
not irq, qpu_num
nop.thrend.never 
nop.never 
nop.never 
```

I think it is convenient for developers to add verbose information to its assembly.
@doe300 Can you review it?