### PR TITLE
Add more circleci build for testing in x86_64 env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,9 +44,8 @@ jobs:
           command: git clone https://github.com/doe300/VC4CLStdLib.git VC4CLStdLib && cd VC4CLStdLib && cmake . && make install && cd ..
       - run:
           name: configure
-          # Use the libLLVM of the default LLVM/CLang, disable search for SPIRV-LLVM
+          # Use SPIRV-LLVM
           command: cmake . -DBUILD_TESTING=ON -DLLVMLIB_FRONTEND=OFF -DSPIRV_FRONTEND=ON
-#          command: cmake . -DCROSS_COMPILE=ON -DBUILD_TESTING=ON -DLLVMLIB_FRONTEND=OFF
       - run:
           name: make
           command: make -j2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,6 @@ jobs:
           command: git clone https://github.com/doe300/VC4CLStdLib.git VC4CLStdLib && cd VC4CLStdLib && cmake . -DCROSS_COMPILE=OFF && make install && cd ..
       - run:
           name: configure
-          # Use SPIRV-LLVM
           command: cmake . -DBUILD_TESTING=ON -DLLVMLIB_FRONTEND=OFF -DLLVMIR_FRONTEND=OFF -DSPIRV_FRONTEND=ON
       - run:
           name: make
@@ -128,7 +127,7 @@ jobs:
       - run: ln -s `pwd`/build/libVC4CC.so.0.4 /usr/lib/libVC4CC.so.1.2
       - run: ln -s `pwd`/build/cpptest-lite/src/cpptest-lite-project-build/libcpptest-lite.so.0.9 /usr/lib/libcpptest-lite.so.1.1.2
       - run: ldconfig
-      - run: build/test/TestVC4C
+      - run: build/test/TestVC4C --output=plain --mode=verbose --test-instructions --test-operators
   test-spirv:
     docker:
       - image: nomaddo/cross-rpi:0.1
@@ -139,7 +138,7 @@ jobs:
       - run: ln -s `pwd`/build/libVC4CC.so.0.4 /usr/lib/libVC4CC.so.1.2
       - run: ln -s `pwd`/build/cpptest-lite/src/cpptest-lite-project-build/libcpptest-lite.so.0.9 /usr/lib/libcpptest-lite.so.1.1.2
       - run: ldconfig
-      - run: build/test/TestVC4C
+      - run: build/test/TestVC4C --output=plain --mode=verbose --test-instructions --test-operators
 workflows:
   version: 2
   commit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,9 @@ jobs:
           name: configure
           command: cmake . -DBUILD_TESTING=ON -DLLVMLIB_FRONTEND=OFF -DLLVMIR_FRONTEND=OFF -DSPIRV_FRONTEND=ON
       - run:
+          name: spirv-tools
+          command: make spirv-tools-project spirv-tools-project-build
+      - run:
           name: make
           command: make -j`nproc`
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,15 +71,15 @@ jobs:
   test:
     docker:
       - image: nomaddo/cross-rpi:0.1
-    require:
-      - build
     steps:
       - checkout
-      - run:
-
+      - run: build/test/TestVC4C
 workflows:
   version: 2
   commit:
     jobs:
       - build
       - cross
+      - test:
+          require:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,20 +67,20 @@ jobs:
       - store_artifacts:
           path: vc4cl-stdlib-0.4-Linux.deb
           distination: vc4cl-stdlib-0.4-Linux.deb
-      - save_cache:
-          key: cache-build-{{ .Branch }}
+      - persist_to_workspace:
+          root: /root/project
           paths:
             - build/libVC4CC.so.0.4
             - build/test/TestVC4C
-            - build/cpptest-lite/src/cpptest-lite-project-build/libcpptest-lite.so
+            - build/cpptest-lite/src/cpptest-lite-project-build/libcpptest-lite.so.0.9
   test:
     docker:
       - image: nomaddo/cross-rpi:0.1
     steps:
-      - restore_cache:
-          key: cache-build-{{ .Branch }}
+      - attach_workspace:
+          at: /root/project
       - run: ln -s `pwd`/build/libVC4CC.so.0.4 /usr/lib/libVC4CC.so.1.2
-      - run: ln -s `pwd`/build/cpptest-lite/src/cpptest-lite-project-build/libcpptest-lite.so /usr/lib/libcpptest-lite.so.1.1.2
+      - run: ln -s `pwd`/build/cpptest-lite/src/cpptest-lite-project-build/libcpptest-lite.so.0.9 /usr/lib/libcpptest-lite.so.1.1.2
       - run: ldconfig
       - run: build/test/TestVC4C
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,5 +80,5 @@ workflows:
       - build
       - cross
       - test:
-          require:
+          requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,11 +67,21 @@ jobs:
       - store_artifacts:
           path: vc4cl-stdlib-0.4-Linux.deb
           distination: vc4cl-stdlib-0.4-Linux.deb
+      - save_cache:
+          key: cache-build-{{ .Branch }}
+          paths:
+            - build/libVC4CC.so.0.4
+            - build/test/TestVC4C
+            - build/cpptest-lite/src/cpptest-lite-project-build/libcpptest-lite.so
   test:
     docker:
       - image: nomaddo/cross-rpi:0.1
     steps:
-      - checkout
+      - restore_cache:
+          key: cache-build-{{ .Branch }}
+      - run: ln -s `pwd`/build/libVC4CC.so.0.4 /usr/lib/libVC4CC.so.1.2
+      - run: ln -s `pwd`/build/cpptest-lite/src/cpptest-lite-project-build/libcpptest-lite.so /usr/lib/libcpptest-lite.so.1.1.2
+      - run: ldconfig
       - run: build/test/TestVC4C
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
       - checkout
       - run:
           name: download header
-          command: git clone https://github.com/doe300/VC4CLStdLib.git VC4CLStdLib && cd VC4CLStdLib && cmake . && make install && cd ..
+          command: git clone https://github.com/doe300/VC4CLStdLib.git VC4CLStdLib && cd VC4CLStdLib && cmake . -DCROSS_COMPILE=OFF && make install && cd ..
       - run:
           name: configure
           # Use SPIRV-LLVM
@@ -83,7 +83,7 @@ jobs:
       - checkout
       - run:
           name: download header
-          command: git clone https://github.com/doe300/VC4CLStdLib.git VC4CLStdLib && cd VC4CLStdLib && cmake . && make install && cd ..
+          command: git clone https://github.com/doe300/VC4CLStdLib.git VC4CLStdLib && cd VC4CLStdLib && cmake . -DCROSS_COMPILE=OFF && make install && cd ..
       - run:
           name: configure
           # Use SPIRV-LLVM

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
 #          command: cmake . -DCROSS_COMPILE=ON -DBUILD_TESTING=ON -DLLVMLIB_FRONTEND=OFF
       - run:
           name: make
-          command: make -j2
+          command: make -j`nproc`
       - run:
           name: deb-packing
           command: cpack -G DEB && cpack -G DEB --config ./VC4CLStdLib/CPackConfig.cmake
@@ -36,7 +36,7 @@ jobs:
           distination: vc4cl-stdlib-0.4-Linux.deb
   build:
     docker:
-      - image: nomaddo/cross-rpi:0.1
+      - image: nomaddo/native
     steps:
       - checkout
       - run:
@@ -45,10 +45,10 @@ jobs:
       - run:
           name: configure
           # Use SPIRV-LLVM
-          command: cmake . -DBUILD_TESTING=ON -DLLVMLIB_FRONTEND=OFF -DSPIRV_FRONTEND=ON
+          command: cmake . -DBUILD_TESTING=ON -DLLVMLIB_FRONTEND=ON -DLLVMIR_FRONTEND=OFF -DSPIRV_FRONTEND=OFF
       - run:
           name: make
-          command: make -j2
+          command: make -j`nproc`
       - run:
           name: deb-packing
           command: cpack -G DEB && cpack -G DEB --config ./VC4CLStdLib/CPackConfig.cmake
@@ -73,12 +73,69 @@ jobs:
             - build/libVC4CC.so.0.4
             - build/test/TestVC4C
             - build/cpptest-lite/src/cpptest-lite-project-build/libcpptest-lite.so.0.9
+            - testing
+            - example
+            - vc4cl-stdlib-0.4-Linux.deb
+  build-spirv:
+    docker:
+      - image: nomaddo/cross-rpi:0.1
+    steps:
+      - checkout
+      - run:
+          name: download header
+          command: git clone https://github.com/doe300/VC4CLStdLib.git VC4CLStdLib && cd VC4CLStdLib && cmake . && make install && cd ..
+      - run:
+          name: configure
+          # Use SPIRV-LLVM
+          command: cmake . -DBUILD_TESTING=ON -DLLVMLIB_FRONTEND=OFF -DLLVMIR_FRONTEND=OFF -DSPIRV_FRONTEND=ON
+      - run:
+          name: make
+          command: make -j`nproc`
+      - run:
+          name: deb-packing
+          command: cpack -G DEB && cpack -G DEB --config ./VC4CLStdLib/CPackConfig.cmake
+      - store_artifacts:
+          path: build/libVC4CC.so.0.4
+          distination: libVC4CC.so.0.4
+      - store_artifacts:
+          path: build/VC4C
+          distination: VC4C
+      - store_artifacts:
+          path: build/test/TestVC4C
+          distination: TestVC4C
+      - store_artifacts:
+          path: vc4c-0.4-Linux.deb
+          distination: vc4c-0.4-Linux.deb
+      - store_artifacts:
+          path: vc4cl-stdlib-0.4-Linux.deb
+          distination: vc4cl-stdlib-0.4-Linux.deb
+      - persist_to_workspace:
+          root: /root/project
+          paths:
+            - build/libVC4CC.so.0.4
+            - build/test/TestVC4C
+            - build/cpptest-lite/src/cpptest-lite-project-build/libcpptest-lite.so.0.9
+            - testing
+            - example
+            - vc4cl-stdlib-0.4-Linux.deb
   test:
+    docker:
+      - image: nomaddo/native
+    steps:
+      - attach_workspace:
+          at: /root/project
+      - run: dpkg -i vc4cl-stdlib-0.4-Linux.deb
+      - run: ln -s `pwd`/build/libVC4CC.so.0.4 /usr/lib/libVC4CC.so.1.2
+      - run: ln -s `pwd`/build/cpptest-lite/src/cpptest-lite-project-build/libcpptest-lite.so.0.9 /usr/lib/libcpptest-lite.so.1.1.2
+      - run: ldconfig
+      - run: build/test/TestVC4C
+  test-spirv:
     docker:
       - image: nomaddo/cross-rpi:0.1
     steps:
       - attach_workspace:
           at: /root/project
+      - run: dpkg -i vc4cl-stdlib-0.4-Linux.deb
       - run: ln -s `pwd`/build/libVC4CC.so.0.4 /usr/lib/libVC4CC.so.1.2
       - run: ln -s `pwd`/build/cpptest-lite/src/cpptest-lite-project-build/libcpptest-lite.so.0.9 /usr/lib/libcpptest-lite.so.1.1.2
       - run: ldconfig
@@ -88,7 +145,11 @@ workflows:
   commit:
     jobs:
       - build
+      - build-spirv
       - cross
       - test:
           requires:
             - build
+      - test-spirv:
+          requires:
+            - build-spirv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  build:
+  cross:
     docker:
       - image: nomaddo/cross-rpi:0.1
     steps:
@@ -34,3 +34,52 @@ jobs:
       - store_artifacts:
           path: vc4cl-stdlib-0.4-Linux.deb
           distination: vc4cl-stdlib-0.4-Linux.deb
+  build:
+    docker:
+      - image: nomaddo/cross-rpi:0.1
+    steps:
+      - checkout
+      - run:
+          name: download header
+          command: git clone https://github.com/doe300/VC4CLStdLib.git VC4CLStdLib && cd VC4CLStdLib && cmake . && make install && cd ..
+      - run:
+          name: configure
+          # Use the libLLVM of the default LLVM/CLang, disable search for SPIRV-LLVM
+          command: cmake . -DBUILD_TESTING=ON -DLLVMLIB_FRONTEND=OFF -DSPIRV_FRONTEND=ON
+#          command: cmake . -DCROSS_COMPILE=ON -DBUILD_TESTING=ON -DLLVMLIB_FRONTEND=OFF
+      - run:
+          name: make
+          command: make -j2
+      - run:
+          name: deb-packing
+          command: cpack -G DEB && cpack -G DEB --config ./VC4CLStdLib/CPackConfig.cmake
+      - store_artifacts:
+          path: build/libVC4CC.so.0.4
+          distination: libVC4CC.so.0.4
+      - store_artifacts:
+          path: build/VC4C
+          distination: VC4C
+      - store_artifacts:
+          path: build/test/TestVC4C
+          distination: TestVC4C
+      - store_artifacts:
+          path: vc4c-0.4-Linux.deb
+          distination: vc4c-0.4-Linux.deb
+      - store_artifacts:
+          path: vc4cl-stdlib-0.4-Linux.deb
+          distination: vc4cl-stdlib-0.4-Linux.deb
+  test:
+    docker:
+      - image: nomaddo/cross-rpi:0.1
+    require:
+      - build
+    steps:
+      - checkout
+      - run:
+
+workflows:
+  version: 2
+  commit:
+    jobs:
+      - build
+      - cross

--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,11 @@ cmake_uninstall.cmake
 compile_commands.json
 install_manifest.txt
 Makefile
+*.deb
+VC4CLStdLib
+_CPack_Packages
 
-# Eclipse 
+# Eclipse
 .cproject
 .project
 .csettings/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,7 +184,7 @@ if(SPIRV_LLVM_SPIR_FOUND AND SPIRV_FRONTEND)
   		  -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
   		  -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
   		  -DCMAKE_FIND_ROOT_PATH=${CMAKE_FIND_ROOT_PATH}
-	)
+	          )
 	add_definitions(-DSPIRV_LLVM_SPIRV_PATH="${SPIRV_LLVM_SPIR_FOUND}")
 	add_definitions(-DSPIRV_HEADER="${PROJECT_SOURCE_DIR}/lib/spirv-headers/include/spirv/1.2/spirv.h")
 	add_definitions(-DSPIRV_OPENCL_HEADER="${PROJECT_SOURCE_DIR}/lib/spirv-headers/include/spirv/1.2/OpenCL.std.h")
@@ -230,10 +230,10 @@ if(LLVMLIB_FRONTEND)
 	else()
 		find_package(LLVM CONFIG)
 		if(LLVM_FOUND)
-			
+
 			#Depending on the LLVM library version used, we need to use some other functions/headers in the LLVM library front-end
 			add_definitions(-DLLVM_LIBRARY_VERSION=${LLVM_VERSION_MAJOR}${LLVM_VERSION_MINOR})
-			
+
 			set(LLVM_LIBS_PATH "${LLVM_LIBRARY_DIRS}")
 			set(LLVM_INCLUDE_PATH "${LLVM_INCLUDE_DIRS}")
 			set(LLVM_LIB_FLAGS "${LLVM_DEFINITIONS}")
@@ -247,7 +247,7 @@ if(LLVMLIB_FRONTEND)
 			set(LLVM_SYSTEM_LIB_NAMES "")
 		endif()
 	endif()
-	
+
 	if(LLVM_LIBS_PATH AND LLVM_INCLUDE_PATH AND LLVM_LIB_FLAGS AND LLVM_LIB_NAMES)
 		message(STATUS "Compiling LLVM library front-end with LLVM in version ${LLVM_LIB_VERSION} located in '${LLVM_LIBS_PATH}'")
 		set(ENABLE_LLVM_LIB_FRONTEND ON)
@@ -340,7 +340,11 @@ if (BUILD_DEB_PACKAGE)
 	set(CPACK_PACKAGE_NAME "vc4c")
 	string(TIMESTAMP BUILD_TIMESTAMP "%Y-%m-%d")
 	set(CPACK_PACKAGE_VERSION "${PROJECT_VERSION}-${BUILD_TIMESTAMP}")
-	set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "armhf")
+	if (CROSS_COMPILE)
+		set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "armhf")
+        else()
+		set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")
+	endif()
 	set(CPACK_DEBIAN_PACKAGE_DEPENDS "opencl-c-headers, clang-3.9, vc4cl-stdlib, llvm-3.9-dev")
 	set(CPACK_PACKAGE_VENDOR "doe300")
 	set(CPACK_PACKAGE_CONTACT "doe300@web.de")

--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-# Status
+# Status 
 
 [![CircleCI](https://circleci.com/gh/doe300/VC4C.svg?style=svg)](https://circleci.com/gh/doe300/VC4C)
 


### PR DESCRIPTION
Related: #39 

This pullreq add more circleci build specially for building x86_64 versions of the compiler for testing.
This pullreq **MUST** accept after this pullreq:
https://github.com/doe300/VC4CLStdLib/pull/4

I added two jobs:

- Build `VC4C` using `SPIRV-LLVM`
- Build `VC4C` using llvm-lib

The purpose of this pullreq is comparison between one of `SPIRV-LLVM` and `LLVM-LIB` with ease.
 