### PR TITLE
Remove constant load in loops

### DIFF
--- a/src/Graph.h
+++ b/src/Graph.h
@@ -23,6 +23,7 @@ namespace vc4c
 	struct Node : private NonCopyable
 	{
 		using NeighborsType = FastMap<Node*, R>;
+		using KeyType = K;
 
 		const K key;
 

--- a/src/analysis/ControlFlowGraph.cpp
+++ b/src/analysis/ControlFlowGraph.cpp
@@ -106,6 +106,8 @@ Optional<InstructionWalker> ControlFlowLoop::findInLoop(const intermediate::Inte
 
 bool ControlFlowLoop::includes(const ControlFlowLoop& other) const
 {
+	if (*this == other) return false;
+
 	auto head = std::find_if(this->begin(), this->end(), [&](const CFGNode* node) {
 		return node->key == (*other.begin())->key;
 	});
@@ -150,7 +152,7 @@ CFGNode& ControlFlowGraph::getEndOfControlFlow()
 			candidate = &node;
 		}
 	}
-	
+
 	if(candidate == nullptr)
 		throw CompilationError(CompilationStep::GENERAL, "Found no CFG node without successors!");
 	return *candidate;
@@ -283,4 +285,19 @@ ControlFlowLoop ControlFlowGraph::findLoopsHelper(const CFGNode* node, FastMap<c
 	}
 
 	return loop;
+}
+
+LoopInclusionTreeNode::LoopInclusionTreeNode(const KeyType key) : Node(key) {}
+
+LoopInclusionTreeNode* LoopInclusionTreeNode::findRoot()
+{
+	for (auto &parent : this->getNeighbors())
+	{
+		if (!parent.second.includes) {
+			// The root node must be only one
+			return reinterpret_cast<LoopInclusionTreeNode*>(parent.first)->findRoot();
+		}
+	}
+	// this is root
+	return this;
 }

--- a/src/analysis/ControlFlowGraph.cpp
+++ b/src/analysis/ControlFlowGraph.cpp
@@ -104,6 +104,27 @@ Optional<InstructionWalker> ControlFlowLoop::findInLoop(const intermediate::Inte
 	return {};
 }
 
+bool ControlFlowLoop::includes(const ControlFlowLoop& other) const
+{
+	auto head = std::find_if(this->begin(), this->end(), [&](const CFGNode* node) {
+		return node->key == (*other.begin())->key;
+	});
+	if (head == this->end())
+ 	{
+		return false;
+	}
+
+	auto thisItr = head;
+	auto otherItr = other.begin();
+	while ((*thisItr)->key == (*otherItr)->key && thisItr != this->end() && otherItr != other.end())
+	{
+		++thisItr;
+		++otherItr;
+	}
+
+	return otherItr == other.end();
+}
+
 CFGNode& ControlFlowGraph::getStartOfControlFlow()
 {
 	//TODO return node without any predecessors?

--- a/src/analysis/ControlFlowGraph.h
+++ b/src/analysis/ControlFlowGraph.h
@@ -132,7 +132,15 @@ namespace vc4c
 		bool includes;
 		LoopInclusion(bool _includes) : includes(_includes) {}
 	};
-	using LoopInclusionTreeNode = Node<ControlFlowLoop*, LoopInclusion>;
+	struct LoopInclusionTreeNode : public Node<ControlFlowLoop*, LoopInclusion>
+	{
+		LoopInclusionTreeNode(const KeyType key);
+		LoopInclusionTreeNode* findRoot();
+	};
+	/*
+	 * The trees represents inclusion relation of control-flow loops. This may have multiple trees.
+	 */
+	using LoopInclusionTree = Graph<ControlFlowLoop*, LoopInclusionTreeNode>;
 
 } /* namespace vc4c */
 

--- a/src/analysis/ControlFlowGraph.h
+++ b/src/analysis/ControlFlowGraph.h
@@ -73,6 +73,11 @@ namespace vc4c
 		 * Returns the InstructionWalker for the given instruction, if it is within the loop.
 		 */
 		Optional<InstructionWalker> findInLoop(const intermediate::IntermediateInstruction* inst) const;
+
+		/*
+		 * Returns whether this loop includes other loop and doesn't equal it.
+		 */
+		bool includes(const ControlFlowLoop& other) const;
 	};
 
 	/*

--- a/src/analysis/ControlFlowGraph.h
+++ b/src/analysis/ControlFlowGraph.h
@@ -124,6 +124,16 @@ namespace vc4c
 		friend class Method;
 	};
 
+	/*
+	 * A relation in the control-flow-loop
+	 */
+	struct LoopInclusion
+	{
+		bool includes;
+		LoopInclusion(bool _includes) : includes(_includes) {}
+	};
+	using LoopInclusionTreeNode = Node<ControlFlowLoop*, LoopInclusion>;
+
 } /* namespace vc4c */
 
 #endif /* VC4C_CONTROLFLOWGRAPH_H */

--- a/src/optimization/ControlFlow.cpp
+++ b/src/optimization/ControlFlow.cpp
@@ -978,7 +978,7 @@ void optimizations::addStartStopSegment(const Module& module, Method& method, co
 void optimizations::removeConstantLoadInLoops(const Module& module, Method& method, const Configuration& config)
 {
 	// 1. find loops
-	auto cfg = ControlFlowGraph::createCFG(method);
+	auto cfg = method.getCFG();
 	auto loops = cfg.findLoops();
 
 	// 2. generate inclusion relation of loops as trees

--- a/src/optimization/ControlFlow.cpp
+++ b/src/optimization/ControlFlow.cpp
@@ -978,7 +978,7 @@ void optimizations::addStartStopSegment(const Module& module, Method& method, co
 void optimizations::removeConstantLoadInLoops(const Module& module, Method& method, const Configuration& config)
 {
 	// 1. find loops
-	auto cfg = method.getCFG();
+	auto &cfg = method.getCFG();
 	auto loops = cfg.findLoops();
 
 	// 2. generate inclusion relation of loops as trees

--- a/src/optimization/ControlFlow.cpp
+++ b/src/optimization/ControlFlow.cpp
@@ -971,3 +971,20 @@ void optimizations::addStartStopSegment(const Module& module, Method& method, co
 
 	generateStopSegment(method);
 }
+
+// TODO: move to headers
+struct NoRelation {};
+using LoopInclusionTreeNode = Node<ControlFlowLoop*, NoRelation>;
+using LoopInclusionTree = Graph<ControlFlowLoop*, LoopInclusionTreeNode>;
+
+void optimizations::removeConstantLoadInLoops(const Module& module, Method& method, const Configuration& config) {
+	logging::debug() << "===================== removeConstantLoadInLoops ============================" << logging::endl;
+
+	// 1. find loops
+	auto cfg = ControlFlowGraph::createCFG(method);
+	auto loops = cfg.findLoops();
+
+	// 2. generate inclusion relation of loops as trees
+
+	// 3. move constant load operations from leaf of trees
+}

--- a/src/optimization/ControlFlow.cpp
+++ b/src/optimization/ControlFlow.cpp
@@ -1042,18 +1042,16 @@ void optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
 			auto block = cfgNode->key;
 			for (auto it = block->begin(); it != block->end(); it = it.nextInBlock())
 			{
- 				// TODO: Constants like `mul24 r1, 4, elem_num` should be also moved.
+				// TODO: Constants like `mul24 r1, 4, elem_num` should be also moved.
 				auto loadInst = it.get<LoadImmediate>();
 				if (loadInst != nullptr)
 				{
 					// LoadImmediate must have output value
 					auto out = loadInst->getOutput().value();
 					if (out.valueType == ValueType::LOCAL) {
- 						// TODO: Fix magic number 2
-  					auto rootCFGNode = *(root->key->end() - 2);
- 						auto rootInst = rootCFGNode->key->begin();
- 						// TODO: Set localPrefix
-						rootInst.previousInMethod().emplace(loadInst->copyFor(method, ""));
+						auto rootInst = method.begin()->end().previousInBlock();
+						// TODO: Set localPrefix
+						rootInst.emplace(loadInst->copyFor(method, ""));
 						it.erase();
 					}
 				}

--- a/src/optimization/ControlFlow.cpp
+++ b/src/optimization/ControlFlow.cpp
@@ -1007,8 +1007,8 @@ void optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
 			{
 				auto &node1 = inclusionTree.getOrCreateNode(&loop1);
 				auto &node2 = inclusionTree.getOrCreateNode(&loop2);
-				node1.addNeighbor(&node2, Inclusion(true));
-				node2.addNeighbor(&node1, Inclusion(false));
+				node1.addNeighbor(&node2, LoopInclusion(true));
+				node2.addNeighbor(&node1, LoopInclusion(false));
 			}
 		}
 	}

--- a/src/optimization/ControlFlow.cpp
+++ b/src/optimization/ControlFlow.cpp
@@ -1050,8 +1050,7 @@ void optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
 					auto out = loadInst->getOutput().value();
 					if (out.valueType == ValueType::LOCAL) {
 						auto rootInst = method.begin()->end().previousInBlock();
-						// TODO: Set localPrefix
-						rootInst.emplace(loadInst->copyFor(method, ""));
+						rootInst.emplace(it.release());
 						it.erase();
 					}
 				}

--- a/src/optimization/ControlFlow.cpp
+++ b/src/optimization/ControlFlow.cpp
@@ -1027,7 +1027,7 @@ void optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
 					// LoadImmediate must have output value
 					auto out = loadInst->getOutput().value();
 					if (out.valueType == ValueType::LOCAL) {
-						auto rootInst = method.begin()->end().previousInBlock();
+						auto rootInst = root->key->findPredecessor()->key->end().previousInBlock();
 						rootInst.emplace(it.release());
 						it.erase();
 					}

--- a/src/optimization/ControlFlow.cpp
+++ b/src/optimization/ControlFlow.cpp
@@ -975,14 +975,6 @@ void optimizations::addStartStopSegment(const Module& module, Method& method, co
 	generateStopSegment(method);
 }
 
-// TODO: move to headers
-struct Inclusion
-{
-	bool includes;
-	Inclusion(bool _includes) : includes(_includes) {}
-};
-using LoopInclusionTreeNode = Node<ControlFlowLoop*, Inclusion>;
-
 LoopInclusionTreeNode* findRoot(LoopInclusionTreeNode *node)
 {
 	for (auto &parent : node->getNeighbors())

--- a/src/optimization/ControlFlow.h
+++ b/src/optimization/ControlFlow.h
@@ -44,6 +44,11 @@ namespace vc4c
 		 */
 		void addStartStopSegment(const Module& module, Method& method, const Configuration& config);
 
+		/*
+		 * Remove constant load in loops
+		 */
+		void removeConstantLoadInLoops(const Module& module, Method& method, const Configuration& config);
+
 	} /* namespace optimizations */
 } /* namespace vc4c */
 

--- a/src/optimization/ControlFlow.h
+++ b/src/optimization/ControlFlow.h
@@ -45,7 +45,7 @@ namespace vc4c
 		void addStartStopSegment(const Module& module, Method& method, const Configuration& config);
 
 		/*
-		 * Remove constant load in loops
+		 * Move constant load operations in (nested) loops to the block before head block of the outer-most loop.
 		 */
 		void removeConstantLoadInLoops(const Module& module, Method& method, const Configuration& config);
 

--- a/src/optimization/Optimizer.cpp
+++ b/src/optimization/Optimizer.cpp
@@ -148,9 +148,11 @@ const OptimizationPass optimizations::COMBINE = OptimizationPass("CombineALUIins
 const OptimizationPass optimizations::UNROLL_WORK_GROUPS = OptimizationPass("UnrollWorkGroups", unrollWorkGroups, 170);
 const OptimizationPass optimizations::ADD_START_STOP_SEGMENT = OptimizationPass("AddStartStopSegment", addStartStopSegment, 180);
 const OptimizationPass optimizations::EXTEND_BRANCHES = OptimizationPass("ExtendBranches", extendBranches, 190);
+// Following index doesn't be considered.
+const OptimizationPass optimizations::REMOVE_CONSTANT_LOAD_IN_LOOPS = OptimizationPass("RemoveConstantLoadInLoops", removeConstantLoadInLoops, 200);
 
 const std::set<OptimizationPass> optimizations::DEFAULT_PASSES = {
-		MAP_MEMORY_ACCESS, RUN_SINGLE_STEPS, /* SPILL_LOCALS, */ COMBINE_LITERAL_LOADS, RESOLVE_STACK_ALLOCATIONS, COMBINE_ROTATIONS, REMOVE_REDUNDANT_MOVES, ELIMINATE, VECTORIZE, SPLIT_READ_WRITES, REORDER, COMBINE, UNROLL_WORK_GROUPS, ADD_START_STOP_SEGMENT, EXTEND_BRANCHES
+		MAP_MEMORY_ACCESS, RUN_SINGLE_STEPS, /* SPILL_LOCALS, */ COMBINE_LITERAL_LOADS, RESOLVE_STACK_ALLOCATIONS, COMBINE_ROTATIONS, REMOVE_REDUNDANT_MOVES, ELIMINATE, VECTORIZE, SPLIT_READ_WRITES, REORDER, COMBINE, UNROLL_WORK_GROUPS, ADD_START_STOP_SEGMENT, EXTEND_BRANCHES, REMOVE_CONSTANT_LOAD_IN_LOOPS
 };
 
 Optimizer::Optimizer(const Configuration& config, const std::set<OptimizationPass>& passes) : config(config), passes(passes)
@@ -162,7 +164,7 @@ static void runOptimizationPasses(const Module& module, Method& method, const Co
     logging::debug() << "-----" << logging::endl;
     logging::info() << "Running optimization passes for: " << method.name << logging::endl;
     std::size_t numInstructions = method.countInstructions();
-    
+
     for(const OptimizationPass& pass : passes)
     {
         logging::debug() << logging::endl;

--- a/src/optimization/Optimizer.cpp
+++ b/src/optimization/Optimizer.cpp
@@ -141,6 +141,7 @@ const OptimizationPass optimizations::COMBINE_LITERAL_LOADS = OptimizationPass("
 const OptimizationPass optimizations::COMBINE_ROTATIONS = OptimizationPass("CombineRotations", combineVectorRotations, 100);
 const OptimizationPass optimizations::REMOVE_REDUNDANT_MOVES = OptimizationPass("RemoveRedundantMoves", eliminateRedundantMoves, 110);
 const OptimizationPass optimizations::ELIMINATE = OptimizationPass("EliminateDeadStores", eliminateDeadStore, 120);
+const OptimizationPass optimizations::REMOVE_CONSTANT_LOAD_IN_LOOPS = OptimizationPass("RemoveConstantLoadInLoops", removeConstantLoadInLoops, 125);
 const OptimizationPass optimizations::VECTORIZE = OptimizationPass("VectorizeLoops", vectorizeLoops, 130);
 const OptimizationPass optimizations::SPLIT_READ_WRITES = OptimizationPass("SplitReadAfterWrites", splitReadAfterWrites, 140);
 const OptimizationPass optimizations::REORDER = OptimizationPass("ReorderInstructions", reorderWithinBasicBlocks, 150);
@@ -148,8 +149,6 @@ const OptimizationPass optimizations::COMBINE = OptimizationPass("CombineALUIins
 const OptimizationPass optimizations::UNROLL_WORK_GROUPS = OptimizationPass("UnrollWorkGroups", unrollWorkGroups, 170);
 const OptimizationPass optimizations::ADD_START_STOP_SEGMENT = OptimizationPass("AddStartStopSegment", addStartStopSegment, 180);
 const OptimizationPass optimizations::EXTEND_BRANCHES = OptimizationPass("ExtendBranches", extendBranches, 190);
-// Following index doesn't be considered.
-const OptimizationPass optimizations::REMOVE_CONSTANT_LOAD_IN_LOOPS = OptimizationPass("RemoveConstantLoadInLoops", removeConstantLoadInLoops, 200);
 
 const std::set<OptimizationPass> optimizations::DEFAULT_PASSES = {
 		MAP_MEMORY_ACCESS, RUN_SINGLE_STEPS, /* SPILL_LOCALS, */ COMBINE_LITERAL_LOADS, RESOLVE_STACK_ALLOCATIONS, COMBINE_ROTATIONS, REMOVE_REDUNDANT_MOVES, ELIMINATE, VECTORIZE, SPLIT_READ_WRITES, REORDER, COMBINE, UNROLL_WORK_GROUPS, ADD_START_STOP_SEGMENT, EXTEND_BRANCHES, REMOVE_CONSTANT_LOAD_IN_LOOPS

--- a/src/optimization/Optimizer.h
+++ b/src/optimization/Optimizer.h
@@ -101,6 +101,8 @@ namespace vc4c
 		extern const OptimizationPass EXTEND_BRANCHES;
 		//adds the start- and stop-segments to the beginning and end of the kernel
 		extern const OptimizationPass ADD_START_STOP_SEGMENT;
+		// remove constant load in (nested) loops
+		extern const OptimizationPass REMOVE_CONSTANT_LOAD_IN_LOOPS;
 
 		/*
 		 * The default optimization passes consist of all passes listed above.

--- a/testing/test_inner_loops.cl
+++ b/testing/test_inner_loops.cl
@@ -1,0 +1,14 @@
+/*
+ * Tests RemoveConstantLoadInLoops optimization
+ */
+__kernel void test_remove_constant_load_in_loops_opt(global float a[], global float b[]) {
+    for (int j = 0; j < 200; j++) {
+        for (int i = 0; i < 200; i++) {
+            a[i + j * 200] = i * j;
+        }
+    }
+
+    for (int i = 0; i < 40000; i++) {
+        b[i] = i;
+    }
+}


### PR DESCRIPTION
Move constant load (`LoadImmediate`) operations in (nested) loop to the block before head block of the outer-most loop.

This PR resolves #21, but moves only constant load, not like `mul24 r1, 4, elem_num`.