### PR TITLE
add clang-format

### DIFF
--- a/.circleci/clang-format-diff.sh
+++ b/.circleci/clang-format-diff.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+RET=0
+DIR=$(readlink -f $(dirname $0)/..)
+
+for file in src/*.cpp src/*/*.cpp include/*.h src/*.h src/*/*.h; do
+    clang-format $file > /tmp/file
+    A=$(diff $file /tmp/file)
+    if [ "$?" == 1 ] || [ "$RET" == 1 ]; then
+        RET=1
+        echo "file: $file"
+        echo "$A"
+    else
+        RET=0
+    fi
+done
+
+exit "${RET}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,11 @@
 version: 2
 jobs:
+  check-code-style:
+    docker:
+      - image: nomaddo/native
+    steps:
+      - checkout
+      - run: .circleci/clang-format-diff.sh
   cross:
     docker:
       - image: nomaddo/cross-rpi:0.1
@@ -146,6 +152,7 @@ workflows:
   version: 2
   commit:
     jobs:
+      - check-code-style
       - build
       - build-spirv
       - cross

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,90 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: false
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories: 
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IndentCaseLabels: false
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        8
+UseTab:          Never
+...
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,21 +76,20 @@ set_target_properties(
 )
 
 find_program(
-  CLANG_PATH
-  clang-format
+  CLANG_FORMAT_PATH
+  NAMES clang-format clang-format-3.8 clang-format-3.9 clang-format-4.0
+  HINTS "/usr/bin" "/usr/local/bin"
   )
 
-if(CLANG_PATH)
-  message (STATUS "found clang-format: ${CLANG_PATH}")
+if(CLANG_FORMAT_PATH)
+  message (STATUS "found clang-format: ${CLANG_FORMAT_PATH}")
   add_custom_target(
-    clangformat
-    COMMAND ${CLANG_PATH}
-    -style=LLVM
-    -i
-    ${SRCS}
+    clang-format
+    COMMAND ${CLANG_FORMAT_PATH}
+    -i ${SRCS}
     )
 else()
-  message (WARNING "clang-format not found: strongly recoomend to use it before commit!")
+  message (WARNING "clang-format not found: strongly recommend to use it before commit!")
 endif()
 
 ##

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,6 +75,24 @@ set_target_properties(
 	SOVERSION "1.2"
 )
 
+find_program(
+  CLANG_PATH
+  clang-format
+  )
+
+if(CLANG_PATH)
+  message (STATUS "found clang-format: ${CLANG_PATH}")
+  add_custom_target(
+    clangformat
+    COMMAND ${CLANG_PATH}
+    -style=LLVM
+    -i
+    ${SRCS}
+    )
+else()
+  message (WARNING "clang-format not found: strongly recoomend to use it before commit!")
+endif()
+
 ##
 # Installation targets
 ##


### PR DESCRIPTION
- check sources are formatted in CI
- add clang-format command to cmake

Discussed in #57.
If new commits are not formatted by clang-format, `check-code-style` failed in CI.
The format style is now created just by `clang-format -dump-config -style=LLVM > .clang-format`.