### PR TITLE
Add optimization option `--fcombine-load-threshold=XXX`

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -105,6 +105,10 @@ namespace vc4c
          * Whether moving of constants to out side of loops
          */
         bool moveConstants = true;
+        /*
+         * The threshold for combineLoadingLiterals
+         */
+        int combineLoadingLiteralsThreshold = 6;
     };
 
     /*

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -207,9 +207,9 @@ int main(int argc, char** argv)
             config.frontend = Frontend::LLVM_IR;
         else if(strcmp("--disassemble", argv[i]) == 0)
             runDisassembler = true;
-        else if(strcmp("--fmoveconstants", argv[i]) == 0)
+        else if(strcmp("--fmove-constants", argv[i]) == 0)
             config.moveConstants = true;
-        else if(strcmp("--fnomoveconstants", argv[i]) == 0)
+        else if(strcmp("--fnomove-constants", argv[i]) == 0)
             config.moveConstants = false;
         else if(strcmp("-o", argv[i]) == 0)
         {
@@ -218,10 +218,8 @@ int main(int argc, char** argv)
             i += 2;
             break;
         }
-        // options for development only
-        else if (auto opt = parseIntOption("--Xthreshold", argv[i]))
+        else if (auto opt = parseIntOption("--fcombine-load-threshold", argv[i]))
         {
-            std::cout << "threshold=" << opt.value() << std::endl;;
             config.combineLoadingLiteralsThreshold = opt.value();
         }
         else

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -110,18 +110,21 @@ Optional<int> parseIntOption(std::string name, std::string input)
     std::stringstream ss(input);
     std::string buffer;
     std::getline(ss, buffer, '=');
-    if (buffer == name)
+    if(buffer == name)
     {
         std::getline(ss, buffer, '=');
-        if (name == buffer)
+        if(name == buffer)
         {
             std::string err = "option parse error: integer required in " + name;
             throw CompilationError(CompilationStep::PRECOMPILATION, err);
         }
-        try {
+        try
+        {
             auto s = std::stoi(buffer);
             return Optional<int>(s);
-        } catch (const std::invalid_argument& e) {
+        }
+        catch(const std::invalid_argument& e)
+        {
             std::string err = "option parse error: integer expected for " + name + ": " + buffer;
             throw CompilationError(CompilationStep::PRECOMPILATION, err);
         }
@@ -218,7 +221,7 @@ int main(int argc, char** argv)
             i += 2;
             break;
         }
-        else if (auto opt = parseIntOption("--fcombine-load-threshold", argv[i]))
+        else if(auto opt = parseIntOption("--fcombine-load-threshold", argv[i]))
         {
             config.combineLoadingLiteralsThreshold = opt.value();
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -102,6 +102,35 @@ static void printInfo()
 }
 
 /*
+ * parse options with parameter like xxx=n
+ * if invalid parameter are passed,
+ */
+Optional<int> parseIntOption(std::string name, std::string input)
+{
+    std::stringstream ss(input);
+    std::string buffer;
+    std::getline(ss, buffer, '=');
+    if (buffer == name)
+    {
+        std::getline(ss, buffer, '=');
+        if (name == buffer)
+        {
+            std::string err = "option parse error: integer required in " + name;
+            throw CompilationError(CompilationStep::PRECOMPILATION, err);
+        }
+        try {
+            auto s = std::stoi(buffer);
+            return Optional<int>(s);
+        } catch (const std::invalid_argument& e) {
+            std::string err = "option parse error: integer expected for " + name + ": " + buffer;
+            throw CompilationError(CompilationStep::PRECOMPILATION, err);
+        }
+    }
+
+    return {};
+}
+
+/*
  *
  */
 int main(int argc, char** argv)
@@ -188,6 +217,12 @@ int main(int argc, char** argv)
             // any further parameter is an input-file
             i += 2;
             break;
+        }
+        // options for development only
+        else if (auto opt = parseIntOption("--Xthreshold", argv[i]))
+        {
+            std::cout << "threshold=" << opt.value() << std::endl;;
+            config.combineLoadingLiteralsThreshold = opt.value();
         }
         else
             options.append(argv[i]).append(" ");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -103,7 +103,7 @@ static void printInfo()
 
 /*
  * parse options with parameter like xxx=n
- * if invalid parameter are passed,
+ * if invalid parameter are passed, raise an exception
  */
 Optional<int> parseIntOption(std::string name, std::string input)
 {
@@ -112,10 +112,13 @@ Optional<int> parseIntOption(std::string name, std::string input)
     std::getline(ss, buffer, '=');
     if(buffer == name)
     {
+        // XXX if input doesn't include '=', `ss` already reached the end.
+        // Then, the second `std::getline` do nothing.
+        // To detect that checking `name` == `buffer` is required.
         std::getline(ss, buffer, '=');
         if(name == buffer)
         {
-            std::string err = "option parse error: integer required in " + name;
+            std::string err = "option parse error: parameter of integer expected in " + name;
             throw CompilationError(CompilationStep::PRECOMPILATION, err);
         }
         try
@@ -125,7 +128,7 @@ Optional<int> parseIntOption(std::string name, std::string input)
         }
         catch(const std::invalid_argument& e)
         {
-            std::string err = "option parse error: integer expected for " + name + ": " + buffer;
+            std::string err = "option parse error: parameter of integer expected in " + name + ", but " + buffer;
             throw CompilationError(CompilationStep::PRECOMPILATION, err);
         }
     }

--- a/src/optimization/Combiner.cpp
+++ b/src/optimization/Combiner.cpp
@@ -588,10 +588,9 @@ static Optional<Literal> getSourceLiteral(InstructionWalker it)
     return {};
 }
 
-static bool canReplaceLiteralLoad(InstructionWalker it, const InstructionWalker start, const InstructionWalker match)
+static bool canReplaceLiteralLoad(InstructionWalker it, const InstructionWalker start, const InstructionWalker match, std::size_t stepsLeft = ACCUMULATOR_THRESHOLD_HINT)
 {
-    std::size_t stepsLeft = ACCUMULATOR_THRESHOLD_HINT;
-    InstructionWalker pos = it;
+    InstructionWalker pos = it.copy();
     // check whether the instruction last loading the same literal is at most ACCUMULATOR_THRESHOLD_HINT instructions
     // before this one
     while(stepsLeft > 0 && !pos.isStartOfBlock() && pos != start)
@@ -620,7 +619,7 @@ void optimizations::combineLoadingLiterals(const Module& module, Method& method,
                 if(literal)
                 {
                     if(lastLoadImmediate.find(literal->unsignedInt()) != lastLoadImmediate.end() &&
-                        canReplaceLiteralLoad(it, block.begin(), lastLoadImmediate.at(literal->unsignedInt())))
+                        canReplaceLiteralLoad(it, block.begin(), lastLoadImmediate.at(literal->unsignedInt()), config.combineLoadingLiteralsThreshold))
                     {
                         Local* oldLocal = it->getOutput()->local;
                         Local* newLocal = lastLoadImmediate.at(literal->unsignedInt())->getOutput()->local;

--- a/src/optimization/Combiner.cpp
+++ b/src/optimization/Combiner.cpp
@@ -588,7 +588,8 @@ static Optional<Literal> getSourceLiteral(InstructionWalker it)
     return {};
 }
 
-static bool canReplaceLiteralLoad(InstructionWalker it, const InstructionWalker start, const InstructionWalker match, std::size_t stepsLeft = ACCUMULATOR_THRESHOLD_HINT)
+static bool canReplaceLiteralLoad(InstructionWalker it, const InstructionWalker start, const InstructionWalker match,
+    std::size_t stepsLeft = ACCUMULATOR_THRESHOLD_HINT)
 {
     InstructionWalker pos = it.copy();
     // check whether the instruction last loading the same literal is at most ACCUMULATOR_THRESHOLD_HINT instructions
@@ -619,7 +620,8 @@ void optimizations::combineLoadingLiterals(const Module& module, Method& method,
                 if(literal)
                 {
                     if(lastLoadImmediate.find(literal->unsignedInt()) != lastLoadImmediate.end() &&
-                        canReplaceLiteralLoad(it, block.begin(), lastLoadImmediate.at(literal->unsignedInt()), config.combineLoadingLiteralsThreshold))
+                        canReplaceLiteralLoad(it, block.begin(), lastLoadImmediate.at(literal->unsignedInt()),
+                            config.combineLoadingLiteralsThreshold))
                     {
                         Local* oldLocal = it->getOutput()->local;
                         Local* newLocal = lastLoadImmediate.at(literal->unsignedInt())->getOutput()->local;

--- a/src/optimization/LiteralValues.cpp
+++ b/src/optimization/LiteralValues.cpp
@@ -791,7 +791,6 @@ InstructionWalker optimizations::handleUseWithImmediate(
                     // and with constant/unsigned, etc.)
                     if(localIt->getSingleWriter() != nullptr)
                         it->addDecorations(intermediate::forwardDecorations(localIt->getSingleWriter()->decoration));
-                    it.nextInBlock();
                     op->replaceLocal(oldLocal, tmp.local, LocalUse::Type::READER);
                 }
             }

--- a/src/optimization/LiteralValues.cpp
+++ b/src/optimization/LiteralValues.cpp
@@ -791,6 +791,7 @@ InstructionWalker optimizations::handleUseWithImmediate(
                     // and with constant/unsigned, etc.)
                     if(localIt->getSingleWriter() != nullptr)
                         it->addDecorations(intermediate::forwardDecorations(localIt->getSingleWriter()->decoration));
+                    it.nextInBlock();
                     op->replaceLocal(oldLocal, tmp.local, LocalUse::Type::READER);
                 }
             }


### PR DESCRIPTION
Related #67.

This pullreq add `--fcombine-load-threshold` to adjust the threshold of `CombineLoadingLiterals`.
The impact of the optimization is huge (which is discussed in #67), users may specify the threshold.

It's better to control it by the compiler, but now there is no good way.

The naming rule is as follows:

- optimization options should be long options.
- the prefix of optimization options should be "--f".
- words should be separated by "-". No captalize.