### PR TITLE
Enhancement Graph

### DIFF
--- a/src/analysis/ControlFlowGraph.cpp
+++ b/src/analysis/ControlFlowGraph.cpp
@@ -248,6 +248,15 @@ ControlFlowGraph ControlFlowGraph::createCFG(Method& method)
 
     // XXX to be exact, would need bidirectional arrow [dir="both"] for compact loops
 #ifdef DEBUG_MODE
+    graph.dumpGraph("/tmp/vc4c-cfg-" + method.name + ".dot");
+#endif
+
+    PROFILE_END(createCFG);
+    return graph;
+}
+
+void ControlFlowGraph::dumpGraph(std::string filename)
+{
     auto nameFunc = [](const BasicBlock* bb) -> std::string { return bb->getLabel()->getLabel()->name; };
     auto edgeLabelFunc = [](const CFGRelation& r) -> std::string {
         return (r.isReverseRelation() && !r.isForwardRelation()) || r.isImplicit ||
@@ -255,12 +264,14 @@ ControlFlowGraph ControlFlowGraph::createCFG(Method& method)
             "" :
             std::string("br ") + r.predecessor->conditional.to_string();
     };
-    DebugGraph<BasicBlock*, CFGRelation>::dumpGraph<ControlFlowGraph>(graph, "/tmp/vc4c-cfg.dot", true, nameFunc,
+    DebugGraph<BasicBlock*, CFGRelation>::dumpGraph<ControlFlowGraph>(*this, filename, true, nameFunc,
         [](const CFGRelation& rel) -> bool { return !rel.isForwardRelation(); }, edgeLabelFunc);
-#endif
+}
 
-    PROFILE_END(createCFG);
-    return graph;
+void ControlFlowGraph::dumpGraph(char * filename)
+{
+    std::string s(filename);
+    dumpGraph(s);
 }
 
 ControlFlowLoop ControlFlowGraph::findLoopsHelper(const CFGNode* node, FastMap<const CFGNode*, int>& discoveryTimes,

--- a/src/analysis/ControlFlowGraph.h
+++ b/src/analysis/ControlFlowGraph.h
@@ -120,6 +120,11 @@ namespace vc4c
          */
         FastAccessList<ControlFlowLoop> findLoops();
 
+        /*
+         * Dump CFG
+         */
+        void dumpGraph(std::string filename);
+        void dumpGraph(char *filename);
     private:
         /*
          * This is a modified version of the Tarjan's Algorithm to find strongly connected components taken from

--- a/test/TestInternalLibs.cpp
+++ b/test/TestInternalLibs.cpp
@@ -1,0 +1,47 @@
+/*
+ * Author: nomaddo
+ *
+ * See the file "LICENSE" for the full license governing this code.
+ */
+
+#include "TestInternalLibs.h"
+#include "Graph.h"
+
+using intGraph = vc4c::Graph<int, vc4c::Node<int, int>>;
+
+void TestInternalLibs::testGraph() {
+  auto graph = intGraph();
+  graph.getOrCreateNode(1).addNeighbor(&graph.getOrCreateNode(1), 0);
+  graph.getOrCreateNode(1).addNeighbor(&graph.getOrCreateNode(2), 1);
+  graph.getOrCreateNode(2).addNeighbor(&graph.getOrCreateNode(1), 2);
+  graph.getOrCreateNode(3).addNeighbor(&graph.getOrCreateNode(1), 3);
+  graph.getOrCreateNode(4).addNeighbor(&graph.getOrCreateNode(1), 4);
+  graph.getOrCreateNode(4).addNeighbor(&graph.getOrCreateNode(2), 4);
+
+  graph.erase(1);
+
+  TEST_ASSERT_EQUALS(3, graph.size());
+  TEST_ASSERT_EQUALS(1, graph.at(4).getNeighbors().size());
+  TEST_ASSERT_EQUALS(0, graph.at(3).getNeighbors().size());
+  TEST_ASSERT_EQUALS(0, graph.at(2).getNeighbors().size());
+  TEST_ASSERT_EQUALS(1, graph.at(2).getPointee().size());
+
+  graph.at(4).erase(&graph.at(2));
+  TEST_ASSERT_EQUALS(0, graph.at(4).getNeighbors().size());
+
+  graph.getOrCreateNode(4).addNeighbor(&graph.getOrCreateNode(2), 5);
+  TEST_ASSERT_EQUALS(1, graph.at(4).getNeighbors().size());
+  TEST_ASSERT_EQUALS(2, graph.at(4).getNeighbors().find(&graph.at(2))->first->key);
+
+  graph.getOrCreateNode(4).addNeighbor(&graph.getOrCreateNode(2), 6);
+  TEST_ASSERT_EQUALS(2, graph.at(4).getNeighbors().size());
+}
+
+TestInternalLibs::TestInternalLibs() {
+  TEST_ADD(TestInternalLibs::testGraph);
+}
+
+TestInternalLibs::~TestInternalLibs()
+{
+
+}

--- a/test/TestInternalLibs.h
+++ b/test/TestInternalLibs.h
@@ -1,0 +1,21 @@
+/*
+ * Author: nomaddo
+ *
+ * See the file "LICENSE" for the full license governing this code.
+ */
+
+#ifndef VC4C_TESTINTERNALLIBS_H
+#define VC4C_TESTINTERNALLIBS_H
+
+#include "cpptest.h"
+
+class TestInternalLibs : public Test::Suite {
+public:
+    TestInternalLibs();
+    ~TestInternalLibs() override;
+
+    void testGraph();
+};
+
+
+#endif //VC4C_TESTINTERNALLIBS_H

--- a/test/sources.list
+++ b/test/sources.list
@@ -19,4 +19,6 @@ target_sources(TestVC4C
     TestStdlib.cpp
     TestStdlib.h
     test_stdlib.h
+    TestInternalLibs.cpp
+    TestInternalLibs.h
 )

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -19,6 +19,7 @@
 
 #include "../lib/cpplog/include/logger.h"
 #include "RegressionTest.h"
+#include "TestInternalLibs.h"
 
 using namespace std;
 
@@ -67,6 +68,7 @@ int main(int argc, char** argv)
     Test::registerSuite(newFastRegressionTest, "fast-regressions", "Runs regression test-cases marked as fast", false);
     Test::registerSuite(Test::newInstance<TestEmulator>, "test-emulator", "Runs selected code-samples through the emulator");
     Test::registerSuite(Test::newInstance<TestStdlib>, "test-stdlib", "Runs most of the VC4CL std-lib functions in emulator");
+    Test::registerSuite(Test::newInstance<TestInternalLibs>, "test-internal-libs", "Test common data structure");
 
     return Test::runSuites(argc, argv);
 }


### PR DESCRIPTION
This solve #79 partially.

- enhance `erase`
- add `pointee` to remember which node is pointing 

Thanks to `pointee` we don't need to add extra edges. 
This pullreq is expected not to change any behaviors of the compiler.
After applying the patch, we need to rewrite some calculations (like making e1 -> e2, and e2 -> e1 even though we want to represent only e1 -> e2).
