### PR TITLE
Fix to use clang-format-5.0

### DIFF
--- a/.circleci/clang-format-diff.sh
+++ b/.circleci/clang-format-diff.sh
@@ -2,12 +2,13 @@
 
 RET=0
 DIR=$(readlink -f $(dirname $0)/..)
+CLANG_FORMAT=clang-format-5.0
 
 echo "Running clang-format in:"
-clang-format --version
+$CLANG_FORMAT --version
 
 for file in src/*.cpp src/*/*.cpp include/*.h src/*.h src/*/*.h; do
-    clang-format $file > /tmp/file
+    $CLANG_FORMAT $file > /tmp/file
     A=$(diff $file /tmp/file)
     if [ "$?" == 1 ] || [ "$RET" == 1 ]; then
         RET=1


### PR DESCRIPTION
At https://github.com/nomaddo/native/pull/1, `clang-format` version was updated to 5.0 in order to fix CI failure in `check-code-style`. With this fix, a program name was changed.