### PR TITLE
Fix RemoveConstantLoadInLoops

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include "Optional.h"
 
 namespace vc4c
 {
@@ -166,6 +167,13 @@ namespace vc4c
          * Manually activated optimizations
          */
         std::unordered_set<std::string> additionalEnabledOptimizations;
+        /*
+         * Depth of loops whose constants are moved to out side of it
+         *
+         * * If it has no value, this optimization will not performed.
+         * * If it has negative value, all constants in loops will be moved.
+         */
+        Optional<int> moveConstantsDepth = Optional<int>(-1);
         /*
          * Manually deactivated optimizations
          */

--- a/include/config.h
+++ b/include/config.h
@@ -131,6 +131,16 @@ namespace vc4c
          * Maximum number of rounds the register-checker tries to resolve conflicts
          */
         unsigned registerResolverMaxRounds = 6;
+
+        /*
+         * Depth of loops whose constants are moved to out side of it
+         *
+         * * If it has no value, this optimization will not performed.
+         * * If it has negative value, all constants in loops will be moved.
+         *
+         * NOTE: This optimization is not enabled by default because it is incomplete.
+         */
+        Optional<int> moveConstantsDepth = {};
     };
 
     /*
@@ -167,15 +177,6 @@ namespace vc4c
          * Manually activated optimizations
          */
         std::unordered_set<std::string> additionalEnabledOptimizations;
-        /*
-         * Depth of loops whose constants are moved to out side of it
-         *
-         * * If it has no value, this optimization will not performed.
-         * * If it has negative value, all constants in loops will be moved.
-         *
-         * NOTE: This optimization is not enabled by default because it is incomplete.
-         */
-        Optional<int> moveConstantsDepth = {};
         /*
          * Manually deactivated optimizations
          */

--- a/include/config.h
+++ b/include/config.h
@@ -7,10 +7,10 @@
 #ifndef VC4C_CONFIG_H
 #define VC4C_CONFIG_H
 
+#include "Optional.h"
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
-#include "Optional.h"
 
 namespace vc4c
 {

--- a/include/config.h
+++ b/include/config.h
@@ -7,7 +7,6 @@
 #ifndef VC4C_CONFIG_H
 #define VC4C_CONFIG_H
 
-#include "Optional.h"
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -140,7 +139,7 @@ namespace vc4c
          *
          * NOTE: This optimization is not enabled by default because it is incomplete.
          */
-        Optional<int> moveConstantsDepth = {};
+        int moveConstantsDepth = -1;
     };
 
     /*

--- a/include/config.h
+++ b/include/config.h
@@ -172,8 +172,10 @@ namespace vc4c
          *
          * * If it has no value, this optimization will not performed.
          * * If it has negative value, all constants in loops will be moved.
+         *
+         * NOTE: This optimization is not enabled by default because it is incomplete.
          */
-        Optional<int> moveConstantsDepth = Optional<int>(-1);
+        Optional<int> moveConstantsDepth = {};
         /*
          * Manually deactivated optimizations
          */

--- a/src/BasicBlock.cpp
+++ b/src/BasicBlock.cpp
@@ -97,6 +97,14 @@ const intermediate::BranchLabel* BasicBlock::getLabel() const
     return dynamic_cast<intermediate::BranchLabel*>(instructions.front().get());
 }
 
+intermediate::BranchLabel* BasicBlock::getLabel()
+{
+    if(dynamic_cast<intermediate::BranchLabel*>(instructions.front().get()) == nullptr)
+        throw CompilationError(
+            CompilationStep::GENERAL, "Basic block does not start with a label", instructions.front()->to_string());
+    return dynamic_cast<intermediate::BranchLabel*>(instructions.front().get());
+}
+
 void BasicBlock::forSuccessiveBlocks(const std::function<void(BasicBlock&)>& consumer) const
 {
     if(method.cfg)

--- a/src/BasicBlock.h
+++ b/src/BasicBlock.h
@@ -85,6 +85,8 @@ namespace vc4c
          * Returns the label for this block
          */
         const intermediate::BranchLabel* getLabel() const;
+        // for modifying label value
+        intermediate::BranchLabel* getLabel();
         /*
          * Runs the consumer function for every block directly following this
          *

--- a/src/Locals.h
+++ b/src/Locals.h
@@ -175,7 +175,7 @@ namespace vc4c
         /*
          * The name of this object
          */
-        const std::string name;
+        std::string name;
         /*
          * Another local (e.g. parameter, global) referenced by this local with the index, if it is a scalar index,
          * otherwise ANY_ELEMENT.

--- a/src/Method.cpp
+++ b/src/Method.cpp
@@ -371,8 +371,9 @@ bool Method::removeBlock(BasicBlock& block, bool overwriteUsages)
 
 BasicBlock& Method::createAndInsertNewBlock(BasicBlockList::iterator position, const std::string& labelName)
 {
+    auto newLabel = locals.emplace(labelName, Local(TYPE_LABEL, labelName));
     return *basicBlocks.emplace(
-        position, *this, new intermediate::BranchLabel(*findOrCreateLocal(TYPE_LABEL, labelName)));
+        position, *this, new intermediate::BranchLabel(newLabel.first->second));
 }
 
 InstructionWalker Method::emplaceLabel(InstructionWalker it, intermediate::BranchLabel* label)

--- a/src/Method.cpp
+++ b/src/Method.cpp
@@ -372,8 +372,7 @@ bool Method::removeBlock(BasicBlock& block, bool overwriteUsages)
 BasicBlock& Method::createAndInsertNewBlock(BasicBlockList::iterator position, const std::string& labelName)
 {
     auto newLabel = locals.emplace(labelName, Local(TYPE_LABEL, labelName));
-    return *basicBlocks.emplace(
-        position, *this, new intermediate::BranchLabel(newLabel.first->second));
+    return *basicBlocks.emplace(position, *this, new intermediate::BranchLabel(newLabel.first->second));
 }
 
 InstructionWalker Method::emplaceLabel(InstructionWalker it, intermediate::BranchLabel* label)

--- a/src/Method.cpp
+++ b/src/Method.cpp
@@ -371,7 +371,8 @@ bool Method::removeBlock(BasicBlock& block, bool overwriteUsages)
 
 BasicBlock& Method::createAndInsertNewBlock(BasicBlockList::iterator position, const std::string& labelName)
 {
-	return *basicBlocks.emplace(position, *this, new intermediate::BranchLabel(*findOrCreateLocal(TYPE_LABEL, labelName)));
+    return *basicBlocks.emplace(
+        position, *this, new intermediate::BranchLabel(*findOrCreateLocal(TYPE_LABEL, labelName)));
 }
 
 InstructionWalker Method::emplaceLabel(InstructionWalker it, intermediate::BranchLabel* label)

--- a/src/Method.cpp
+++ b/src/Method.cpp
@@ -369,6 +369,11 @@ bool Method::removeBlock(BasicBlock& block, bool overwriteUsages)
     return false;
 }
 
+BasicBlock& Method::createAndInsertNewBlock(BasicBlockList::iterator position, const std::string& labelName)
+{
+	return *basicBlocks.emplace(position, *this, new intermediate::BranchLabel(*findOrCreateLocal(TYPE_LABEL, labelName)));
+}
+
 InstructionWalker Method::emplaceLabel(InstructionWalker it, intermediate::BranchLabel* label)
 {
     auto blockIt = begin();

--- a/src/Method.h
+++ b/src/Method.h
@@ -208,6 +208,11 @@ namespace vc4c
         bool removeBlock(BasicBlock& block, bool overwriteUsages = false);
 
         /*
+         * Create new basic block and Insert it into position.
+         */
+        BasicBlock& createAndInsertNewBlock(BasicBlockList::iterator position, const std::string& labelName);
+
+        /*
          * Inserts the given label at the position and returns a iterator to it.
          *
          * This function splits the current basic block, moving all following instructions to the newly created basic

--- a/src/intermediate/Branching.cpp
+++ b/src/intermediate/Branching.cpp
@@ -50,7 +50,7 @@ const Local* BranchLabel::getLabel() const
 
 Local* BranchLabel::getLabel()
 {
-    return getArgument(0)->local;
+    return assertArgument(0).local;
 }
 
 Branch::Branch(const Local* target, const ConditionCode condCode, const Value& cond) :

--- a/src/intermediate/Branching.cpp
+++ b/src/intermediate/Branching.cpp
@@ -48,6 +48,11 @@ const Local* BranchLabel::getLabel() const
     return assertArgument(0).local;
 }
 
+Local* BranchLabel::getLabel()
+{
+    return getArgument(0)->local;
+}
+
 Branch::Branch(const Local* target, const ConditionCode condCode, const Value& cond) :
     IntermediateInstruction(NO_VALUE, condCode)
 {

--- a/src/intermediate/IntermediateInstruction.h
+++ b/src/intermediate/IntermediateInstruction.h
@@ -361,6 +361,7 @@ namespace vc4c
             bool isNormalized() const override;
 
             const Local* getLabel() const;
+            Local* getLabel();
         };
 
         struct Branch : public IntermediateInstruction

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -182,13 +182,6 @@ int main(int argc, char** argv)
             setLogger(std::wcout, true, LogLevel::DEBUG);
         else if(strcmp("--disassemble", argv[i]) == 0)
             runDisassembler = true;
-        else if(auto opt = parseIntOption("--fmove-constants", argv[i]))
-        {
-            // Optional of opt and moveConstantsDepth are different.
-            config.moveConstantsDepth = Optional<int>(opt.value());
-        }
-        else if(strcmp("--fnomove-constants", argv[i]) == 0)
-            config.moveConstantsDepth = {};
         else if(strcmp("-o", argv[i]) == 0)
         {
             outputFile = argv[i + 1];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -182,6 +182,13 @@ int main(int argc, char** argv)
             setLogger(std::wcout, true, LogLevel::DEBUG);
         else if(strcmp("--disassemble", argv[i]) == 0)
             runDisassembler = true;
+        else if(auto opt = parseIntOption("--fmove-constants", argv[i]))
+        {
+            // Optional of opt and moveConstantsDepth are different.
+            config.moveConstantsDepth = Optional<int>(opt.value());
+        }
+        else if(strcmp("--fnomove-constants", argv[i]) == 0)
+            config.moveConstantsDepth = {};
         else if(strcmp("-o", argv[i]) == 0)
         {
             outputFile = argv[i + 1];

--- a/src/normalization/Normalizer.cpp
+++ b/src/normalization/Normalizer.cpp
@@ -176,6 +176,15 @@ void Normalizer::normalizeMethod(Module& module, Method& method) const
     PROFILE_END(AddStartStopSegment);
 
     PROFILE_END(NormalizationPasses);
+
+    // add (runtime-configurable) loop over the whole kernel execution, allowing for skipping some of the syscall
+    // overhead for kernels with many work-groups
+    logging::debug() << logging::endl;
+    logging::debug() << "Running pass: UnrollWorkGroups" << logging::endl;
+    PROFILE_START(UnrollWorkGroups);
+    optimizations::unrollWorkGroups(module, method, config);
+    PROFILE_END(UnrollWorkGroups);
+
     logging::info() << logging::endl;
     if(numInstructions != method.countInstructions())
     {
@@ -196,14 +205,6 @@ void Normalizer::adjustMethod(Module& module, Method& method) const
     std::size_t numInstructions = method.countInstructions();
 
     PROFILE_START(AdjustmentPasses);
-
-    // add (runtime-configurable) loop over the whole kernel execution, allowing for skipping some of the syscall
-    // overhead for kernels with many work-groups
-    logging::debug() << logging::endl;
-    logging::debug() << "Running pass: UnrollWorkGroups" << logging::endl;
-    PROFILE_START(UnrollWorkGroups);
-    optimizations::unrollWorkGroups(module, method, config);
-    PROFILE_END(UnrollWorkGroups);
 
     for(const auto& step : adjustmentSteps)
     {

--- a/src/optimization/ControlFlow.cpp
+++ b/src/optimization/ControlFlow.cpp
@@ -1135,6 +1135,7 @@ void optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
             continue;
         processed.insert(root->key);
 
+        // to prevent multiple block creation
         BasicBlock *insertedBlock = nullptr;
 
         for(auto& cfgNode : *root->key)
@@ -1165,8 +1166,17 @@ void optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
                             else
                             {
                                 logging::debug() << "Create a new basic block before the root of inclusion tree" << logging::endl;
+
+                                auto headBlock = method.begin();
+
                                 insertedBlock = &method.createAndInsertNewBlock(method.begin(), "%createdByRemoveConstantLoadInLoops");
                                 insertedBlock->end().emplace(it.release());
+
+                                if(headBlock->getLabel()->getLabel()->name == BasicBlock::DEFAULT_BLOCK)
+                                {
+                                    // swap labels because DEFAULT_BLOCK is treated as head block.
+                                    headBlock->getLabel()->getLabel()->name.swap(insertedBlock->getLabel()->getLabel()->name);
+                                }
                             }
                         }
                         it.erase();

--- a/src/optimization/ControlFlow.cpp
+++ b/src/optimization/ControlFlow.cpp
@@ -1091,13 +1091,7 @@ void optimizations::addStartStopSegment(const Module& module, Method& method, co
 
 void optimizations::removeConstantLoadInLoops(const Module& module, Method& method, const Configuration& config)
 {
-    if(!config.additionalOptions.moveConstantsDepth.has_value())
-    {
-        logging::debug() << "skipped RemoveConstantLoadInLoops" << logging::endl;
-        return;
-    }
-
-    logging::debug() << "moveConstantsDepth = " << config.additionalOptions.moveConstantsDepth.value() << logging::endl;
+    logging::debug() << "moveConstantsDepth = " << config.additionalOptions.moveConstantsDepth << logging::endl;
 
     // 1. find loops
     auto& cfg = method.getCFG();

--- a/src/optimization/ControlFlow.cpp
+++ b/src/optimization/ControlFlow.cpp
@@ -1091,7 +1091,8 @@ void optimizations::addStartStopSegment(const Module& module, Method& method, co
 
 void optimizations::removeConstantLoadInLoops(const Module& module, Method& method, const Configuration& config)
 {
-    if(!config.additionalOptions.moveConstantsDepth.has_value()) {
+    if(!config.additionalOptions.moveConstantsDepth.has_value())
+    {
         logging::debug() << "skipped RemoveConstantLoadInLoops" << logging::endl;
         return;
     }
@@ -1138,7 +1139,7 @@ void optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
         processed.insert(root->key);
 
         // to prevent multiple block creation
-        BasicBlock *insertedBlock = nullptr;
+        BasicBlock* insertedBlock = nullptr;
 
         for(auto& cfgNode : *root->key)
         {
@@ -1167,17 +1168,20 @@ void optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
                             }
                             else
                             {
-                                logging::debug() << "Create a new basic block before the root of inclusion tree" << logging::endl;
+                                logging::debug()
+                                    << "Create a new basic block before the root of inclusion tree" << logging::endl;
 
                                 auto headBlock = method.begin();
 
-                                insertedBlock = &method.createAndInsertNewBlock(method.begin(), "%createdByRemoveConstantLoadInLoops");
+                                insertedBlock = &method.createAndInsertNewBlock(
+                                    method.begin(), "%createdByRemoveConstantLoadInLoops");
                                 insertedBlock->end().emplace(it.release());
 
                                 if(headBlock->getLabel()->getLabel()->name == BasicBlock::DEFAULT_BLOCK)
                                 {
                                     // swap labels because DEFAULT_BLOCK is treated as head block.
-                                    headBlock->getLabel()->getLabel()->name.swap(insertedBlock->getLabel()->getLabel()->name);
+                                    headBlock->getLabel()->getLabel()->name.swap(
+                                        insertedBlock->getLabel()->getLabel()->name);
                                 }
                             }
                         }

--- a/src/optimization/ControlFlow.cpp
+++ b/src/optimization/ControlFlow.cpp
@@ -1091,10 +1091,12 @@ void optimizations::addStartStopSegment(const Module& module, Method& method, co
 
 void optimizations::removeConstantLoadInLoops(const Module& module, Method& method, const Configuration& config)
 {
-    if(!config.moveConstantsDepth.has_value())
+    if(!config.additionalOptions.moveConstantsDepth.has_value()) {
+        logging::debug() << "skipped RemoveConstantLoadInLoops" << logging::endl;
         return;
+    }
 
-    logging::debug() << "moveConstantsDepth = " << config.moveConstantsDepth.value() << logging::endl;
+    logging::debug() << "moveConstantsDepth = " << config.additionalOptions.moveConstantsDepth.value() << logging::endl;
 
     // 1. find loops
     auto& cfg = method.getCFG();

--- a/src/optimization/ControlFlow.cpp
+++ b/src/optimization/ControlFlow.cpp
@@ -1091,6 +1091,11 @@ void optimizations::addStartStopSegment(const Module& module, Method& method, co
 
 void optimizations::removeConstantLoadInLoops(const Module& module, Method& method, const Configuration& config)
 {
+    if(!config.moveConstantsDepth.has_value())
+        return;
+
+    logging::debug() << "moveConstantsDepth = " << config.moveConstantsDepth.value() << logging::endl;
+
     // 1. find loops
     auto& cfg = method.getCFG();
     auto loops = cfg.findLoops();

--- a/src/optimization/ControlFlow.cpp
+++ b/src/optimization/ControlFlow.cpp
@@ -1157,7 +1157,7 @@ void optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
                             auto targetBlock = root->key->findPredecessor();
                             if(targetBlock != nullptr)
                             {
-                                auto targetInst = targetBlock->key->end().previousInBlock();
+                                auto targetInst = targetBlock->key->end();
                                 targetInst.emplace(it.release());
                             }
                             else

--- a/src/optimization/Optimizer.cpp
+++ b/src/optimization/Optimizer.cpp
@@ -192,8 +192,8 @@ const std::vector<OptimizationPass> Optimizer::ALL_PASSES = {
      * loop having wrong value for successive iterations In register-allocation, need to check for loops and reserve
      * whole loop
      */
-    //    OptimizationPass("RemoveConstantLoadInLoops", "extract-loads-from-loops", removeConstantLoadInLoops,
-    //        "move constant loads in (nested) loops outside the loops"),
+    OptimizationPass("RemoveConstantLoadInLoops", "extract-loads-from-loops", removeConstantLoadInLoops,
+        "move constant loads in (nested) loops outside the loops"),
     OptimizationPass("EliminateDeadStores", "eliminate-dead-store", eliminateDeadStore,
         "eliminates useless instructions (dead store, move to same, redundant arithmetic operations, ...)"),
     OptimizationPass("VectorizeLoops", "vectorize-loops", vectorizeLoops, "vectorizes loops"),

--- a/src/tools/options.cpp
+++ b/src/tools/options.cpp
@@ -94,7 +94,7 @@ bool tools::parseConfigurationParameter(Configuration& config, const std::string
     std::string passName;
     if(arg.find("--fno-") == 0)
     {
-        passName = arg.substr(std::string("--f-no-").size() - 1);
+        passName = arg.substr(std::string("--fno-").size());
         if(availableOptimizations.find(passName) != availableOptimizations.end())
         {
             config.additionalDisabledOptimizations.emplace(passName);
@@ -132,6 +132,8 @@ bool tools::parseConfigurationParameter(Configuration& config, const std::string
                 config.additionalOptions.replaceNopThreshold = intValue;
             else if(paramName == "register-resolver-rounds")
                 config.additionalOptions.registerResolverMaxRounds = intValue;
+            else if(paramName == "extract-loads-from-loops")
+                config.additionalOptions.moveConstantsDepth = Optional<int>(intValue);
             else
             {
                 std::cerr << "Cannot set unknown optimization parameter: " << paramName << " to " << value << std::endl;

--- a/src/tools/options.cpp
+++ b/src/tools/options.cpp
@@ -132,7 +132,7 @@ bool tools::parseConfigurationParameter(Configuration& config, const std::string
                 config.additionalOptions.replaceNopThreshold = intValue;
             else if(paramName == "register-resolver-rounds")
                 config.additionalOptions.registerResolverMaxRounds = intValue;
-            else if(paramName == "extract-loads-from-loops")
+            else if(paramName == "move-constants-depth")
                 config.additionalOptions.moveConstantsDepth = Optional<int>(intValue);
             else
             {

--- a/src/tools/options.cpp
+++ b/src/tools/options.cpp
@@ -133,7 +133,7 @@ bool tools::parseConfigurationParameter(Configuration& config, const std::string
             else if(paramName == "register-resolver-rounds")
                 config.additionalOptions.registerResolverMaxRounds = intValue;
             else if(paramName == "move-constants-depth")
-                config.additionalOptions.moveConstantsDepth = Optional<int>(intValue);
+                config.additionalOptions.moveConstantsDepth = intValue;
             else
             {
                 std::cerr << "Cannot set unknown optimization parameter: " << paramName << " to " << value << std::endl;


### PR DESCRIPTION
This fix enables moving constants in loops generated by UnrollWorkGroups (it's labeled `%start_of_function`).

For example, following code is compiled to next.

```opencl
__kernel void test_method (__global float * a){
  int i = get_local_id(0);
  a[i] = a[i] * 2;
}
```

```asm
// Module with 1 kernels, global data with 0 words (64-bit each), starting at offset 1 words and 0 words of stack-frame
// Kernel 'test_method' with 27 instructions, offset 2, with following parameters: __global out float* a (4 B, 1 items) (lids)
// label: %start_of_function
ldi r2, 255
ldi r1, 255
// label: %createdByRemoveConstantLoadInLoops
and r0, unif, r2
and r0, r0, r1
shl r0, r0, 2 (2)
add r0, unif, r0
nop.never 
or tmu0s, r0, r0
nop.load_tmu0.never 
or -, mutex_acq, mutex_acq
ldi vpw_setup, vpm_setup(size: 16 words, stride: 1 rows, address: h32(0))
fmul vpm, r4, 2.000000 (33)
ldi vpw_setup, vdw_setup(rows: 1, elements: 1 words, address: h32(0))
ldi vpw_setup, vdw_setup(stride: 0)
or vpw_addr, r0, r0
or -, vpw_wait, vpw_wait
or mutex_rel, 1 (1), 1 (1)
// label: %end_of_function
or r0, unif, unif
or.setf -, elem_num, r0
brr.ifallzc (pc+4) + -21 // to %createdByRemoveConstantLoadInLoops
nop.never 
nop.never 
nop.never 
not irq, qpu_num
nop.thrend.never 
nop.never 
nop.never 
```

I understanding RemoveConstantLoadInLoops's problem (it generates invalid code, for example `testing/test_barrier.cl`). So it is disabled by default (you can test it by adding option `--fextract-loads-from-loops=-1`) and I will fix it in next PR.
