### PR TITLE
Improve RemoveConstantLoadInLoops

### DIFF
--- a/src/Graph.h
+++ b/src/Graph.h
@@ -84,6 +84,11 @@ namespace vc4c
             return graph.createEdge(this, neighbor, std::forward<Relation&&>(relation));
         }
 
+        void removeNeighbor(Node* neighbor)
+        {
+            neighbors.erase(neighbor);
+        }
+
         EdgeType& getOrCreateEdge(Node* neighbor, Relation&& defaultRelation = {})
         {
             auto it = edges.find(neighbor);

--- a/src/Graph.h
+++ b/src/Graph.h
@@ -84,11 +84,6 @@ namespace vc4c
             return graph.createEdge(this, neighbor, std::forward<Relation&&>(relation));
         }
 
-        void removeNeighbor(Node* neighbor)
-        {
-            neighbors.erase(neighbor);
-        }
-
         EdgeType& getOrCreateEdge(Node* neighbor, Relation&& defaultRelation = {})
         {
             auto it = edges.find(neighbor);

--- a/src/Graph.h
+++ b/src/Graph.h
@@ -695,6 +695,11 @@ namespace vc4c
             return nodes;
         }
 
+        FastMap<Key, NodeType>& getNodes()
+        {
+            return nodes;
+        }
+
         void forAllNodes(const std::function<void(NodeType&)>& consumer)
         {
             std::for_each(nodes.begin(), nodes.end(), [&](auto& pair) { consumer(pair.second); });

--- a/src/InstructionWalker.h
+++ b/src/InstructionWalker.h
@@ -145,7 +145,7 @@ namespace vc4c
         template <typename T>
         inline const T* get() const
         {
-            return dynamic_cast<T*>(get());
+            return dynamic_cast<const T*>(get());
         }
 
         /*

--- a/src/analysis/ControlFlowGraph.cpp
+++ b/src/analysis/ControlFlowGraph.cpp
@@ -133,10 +133,11 @@ bool ControlFlowLoop::includes(const ControlFlowLoop& other) const
     if(*this == other)
         return false;
 
-    for (auto otherItr : other) {
-        auto thisItr = std::find_if(
-            begin(), end(), [&](const CFGNode* node) { return node->key == otherItr->key; });
-        if (thisItr == end()) {
+    for(auto otherItr : other)
+    {
+        auto thisItr = std::find_if(begin(), end(), [&](const CFGNode* node) { return node->key == otherItr->key; });
+        if(thisItr == end())
+        {
             return false;
         }
     }
@@ -256,17 +257,19 @@ void ControlFlowGraph::dumpGraph(const std::string& path, bool dumpInstructions)
 #ifdef DEBUG_MODE
     // XXX to be exact, would need bidirectional arrow [dir="both"] for compact loops
     auto nameFunc = [&dumpInstructions](const BasicBlock* bb) -> std::string {
-        if (dumpInstructions) {
+        if(dumpInstructions)
+        {
             std::stringstream ss;
             ss << bb->getLabel()->getLabel()->name << "\\n";
             std::for_each(bb->instructions.begin(), bb->instructions.end(),
-                    [&ss](const std::unique_ptr<intermediate::IntermediateInstruction>& instr) {
+                [&ss](const std::unique_ptr<intermediate::IntermediateInstruction>& instr) {
                     if(instr && instr->isConstantInstruction())
-                    ss << instr->to_string() << "\\l";
-                    });
+                        ss << instr->to_string() << "\\l";
+                });
             return ss.str();
         }
-        else {
+        else
+        {
             return bb->getLabel()->getLabel()->name;
         }
     };
@@ -552,35 +555,35 @@ FastAccessList<ControlFlowLoop> ControlFlowGraph::findLoopsHelperRecursively(con
     FastAccessList<ControlFlowLoop> loops;
 
     // Go through all vertices adjacent to this
-    node->forAllOutgoingEdges([this, node, &discoveryTimes, &stack, &time, &loops](
-                                  const CFGNode& next, const CFGEdge& edge) -> bool {
-        const CFGNode* v = &next;
+    node->forAllOutgoingEdges(
+        [this, node, &discoveryTimes, &stack, &time, &loops](const CFGNode& next, const CFGEdge& edge) -> bool {
+            const CFGNode* v = &next;
 
-        // Create a loop including 'v' only of 'v' is still in stack
-        if(std::find(stack.begin(), stack.end(), v) != stack.end() && node != v)
-        {
-            ControlFlowLoop loop;
-            RandomModificationList<const CFGNode*> tempStack = stack;
-
-            while(tempStack.back() != v)
+            // Create a loop including 'v' only of 'v' is still in stack
+            if(std::find(stack.begin(), stack.end(), v) != stack.end() && node != v)
             {
+                ControlFlowLoop loop;
+                RandomModificationList<const CFGNode*> tempStack = stack;
+
+                while(tempStack.back() != v)
+                {
+                    loop.push_back(tempStack.back());
+                    tempStack.pop_back();
+                }
                 loop.push_back(tempStack.back());
                 tempStack.pop_back();
+
+                loops.emplace_back(std::move(loop));
             }
-            loop.push_back(tempStack.back());
-            tempStack.pop_back();
+            else if(node != v)
+            {
+                auto subLoops = findLoopsHelperRecursively(v, discoveryTimes, stack, time);
+                if(subLoops.size() >= 1)
+                    loops.insert(loops.end(), subLoops.begin(), subLoops.end());
+            }
 
-            loops.emplace_back(std::move(loop));
-        }
-        else if (node != v)
-        {
-            auto subLoops = findLoopsHelperRecursively(v, discoveryTimes, stack, time);
-            if(subLoops.size() >= 1)
-                loops.insert(loops.end(), subLoops.begin(), subLoops.end());
-        }
-
-        return true;
-    });
+            return true;
+        });
 
     stack.pop_back();
 
@@ -589,20 +592,22 @@ FastAccessList<ControlFlowLoop> ControlFlowGraph::findLoopsHelperRecursively(con
 
 // LoopInclusionTreeNodeBase::LoopInclusionTreeNodeBase(const KeyType key) : Node(key) {}
 
-LoopInclusionTreeNode* castToTreeNode(LoopInclusionTreeNodeBase *base) {
+LoopInclusionTreeNode* castToTreeNode(LoopInclusionTreeNodeBase* base)
+{
     auto* node = dynamic_cast<LoopInclusionTreeNode*>(base);
-    if (node == nullptr) {
-        throw CompilationError(
-                CompilationStep::OPTIMIZER, "Cannot downcast to LoopInclusionTreeNode.");
+    if(node == nullptr)
+    {
+        throw CompilationError(CompilationStep::OPTIMIZER, "Cannot downcast to LoopInclusionTreeNode.");
     }
     return node;
 }
 
-const LoopInclusionTreeNode* castToTreeNode(const LoopInclusionTreeNodeBase *base) {
+const LoopInclusionTreeNode* castToTreeNode(const LoopInclusionTreeNodeBase* base)
+{
     auto* node = dynamic_cast<const LoopInclusionTreeNode*>(base);
-    if (node == nullptr) {
-        throw CompilationError(
-                CompilationStep::OPTIMIZER, "Cannot downcast to LoopInclusionTreeNode.");
+    if(node == nullptr)
+    {
+        throw CompilationError(CompilationStep::OPTIMIZER, "Cannot downcast to LoopInclusionTreeNode.");
     }
     return node;
 }
@@ -680,5 +685,3 @@ std::string LoopInclusionTreeNodeBase::dumpLabel() const
     auto* self = castToTreeNode(this);
     return (*self->key->rbegin())->key->getLabel()->to_string();
 }
-
-

--- a/src/analysis/ControlFlowGraph.cpp
+++ b/src/analysis/ControlFlowGraph.cpp
@@ -252,12 +252,12 @@ FastAccessList<ControlFlowLoop> ControlFlowGraph::findLoops(bool recursively)
 }
 
 LCOV_EXCL_START
-void ControlFlowGraph::dumpGraph(const std::string& path, bool dumpInstructions) const
+void ControlFlowGraph::dumpGraph(const std::string& path, bool dumpConstantLoadInstructions) const
 {
 #ifdef DEBUG_MODE
     // XXX to be exact, would need bidirectional arrow [dir="both"] for compact loops
-    auto nameFunc = [&dumpInstructions](const BasicBlock* bb) -> std::string {
-        if(dumpInstructions)
+    auto nameFunc = [&dumpConstantLoadInstructions](const BasicBlock* bb) -> std::string {
+        if(dumpConstantLoadInstructions)
         {
             std::stringstream ss;
             ss << bb->getLabel()->getLabel()->name << "\\n";

--- a/src/analysis/ControlFlowGraph.cpp
+++ b/src/analysis/ControlFlowGraph.cpp
@@ -513,6 +513,23 @@ std::unique_ptr<ControlFlowGraph> ControlFlowGraph::createCFG(Method& method)
     return graph;
 }
 
+std::unique_ptr<ControlFlowGraph> ControlFlowGraph::clone() {
+    std::unique_ptr<ControlFlowGraph> graph(new ControlFlowGraph());
+
+    for(auto &node : nodes) {
+        auto &newNode = graph->getOrCreateNode(node.first);
+        node.second.forAllIncomingEdges([&newNode, &graph](const CFGNode& source, const CFGEdge& edge) -> bool {
+                auto &newSource = graph->getOrCreateNode(source.key);
+                auto &newEdge = newSource.getOrCreateEdge(&newNode, CFGRelation{}).addInput(newSource);
+                newEdge.data.isImplicit.emplace(source.key, edge.data.isImplicit.at(source.key));
+                newEdge.data.predecessors.emplace(source.key, edge.data.predecessors.at(source.key));
+                return true;
+            });
+    }
+
+    return graph;
+}
+
 ControlFlowLoop ControlFlowGraph::findLoopsHelper(const CFGNode* node, FastMap<const CFGNode*, int>& discoveryTimes,
     FastMap<const CFGNode*, int>& lowestReachable, FastModificationList<const CFGNode*>& stack, int& time)
 {

--- a/src/analysis/ControlFlowGraph.cpp
+++ b/src/analysis/ControlFlowGraph.cpp
@@ -133,6 +133,17 @@ bool ControlFlowLoop::includes(const ControlFlowLoop& other) const
     if(*this == other)
         return false;
 
+    for (auto otherItr : other) {
+        auto thisItr = std::find_if(
+            begin(), end(), [&](const CFGNode* node) { return node->key == otherItr->key; });
+        if (thisItr == end()) {
+            return true;
+        }
+    }
+
+    return false;
+
+    /*
     auto head = std::find_if(
         this->begin(), this->end(), [&](const CFGNode* node) { return node->key == (*other.begin())->key; });
     if(head == this->end())
@@ -149,6 +160,7 @@ bool ControlFlowLoop::includes(const ControlFlowLoop& other) const
     }
 
     return otherItr == other.end();
+    */
 }
 
 CFGNode& ControlFlowGraph::getStartOfControlFlow()
@@ -565,16 +577,8 @@ FastAccessList<ControlFlowLoop> ControlFlowGraph::findLoopsHelperRecursively(con
                                   const CFGNode& next, const CFGEdge& edge) -> bool {
         const CFGNode* v = &next;
 
-        // If v is not visited yet, then recur for it
-        if(discoveryTimes[v] == 0)
-        {
-            auto subLoops = findLoopsHelperRecursively(v, discoveryTimes, stack, time);
-            if(subLoops.size() >= 1)
-                loops.insert(loops.end(), subLoops.begin(), subLoops.end());
-        }
-
         // Create a loop including 'v' only of 'v' is still in stack
-        else if(std::find(stack.begin(), stack.end(), v) != stack.end() && node != v)
+        if(std::find(stack.begin(), stack.end(), v) != stack.end() && node != v)
         {
             ControlFlowLoop loop;
             RandomModificationList<const CFGNode*> tempStack = stack;
@@ -589,11 +593,20 @@ FastAccessList<ControlFlowLoop> ControlFlowGraph::findLoopsHelperRecursively(con
 
             loops.emplace_back(std::move(loop));
         }
+        // If v is not visited yet, then recur for it
+        else if (node != v) /*if(discoveryTimes[v] < discoveryTimes[node])*/
+        {
+            auto subLoops = findLoopsHelperRecursively(v, discoveryTimes, stack, time);
+            if(subLoops.size() >= 1)
+                loops.insert(loops.end(), subLoops.begin(), subLoops.end());
+        }
 
         return true;
     });
 
     stack.pop_back();
+
+    logging::debug() << "pop: " << node->key->getLabel()->getLabel()->to_string() << logging::endl;
 
     return loops;
 }
@@ -689,7 +702,9 @@ bool LoopInclusionTreeNodeBase::hasCFGNodeInChildren(const CFGNode* node) const
 std::string LoopInclusionTreeNodeBase::dumpLabel() const
 {
     auto* self = castToTreeNode(this);
-    return (*self->key->rbegin())->key->getLabel()->to_string();
+    std::stringstream ss;
+    ss << this;
+    return (*self->key->rbegin())->key->getLabel()->to_string() + " @ " + ss.str();
 }
 
 

--- a/src/analysis/ControlFlowGraph.cpp
+++ b/src/analysis/ControlFlowGraph.cpp
@@ -580,7 +580,7 @@ LoopInclusionTreeNodeBase::LoopInclusionTreeNodeBase(const KeyType key) : Node(k
 
 LoopInclusionTreeNodeBase* LoopInclusionTreeNodeBase::findRoot(Optional<int> depth)
 {
-    if (depth && depth.value() == 0)
+    if(depth && depth.value() == 0)
     {
         return this;
     }
@@ -596,12 +596,12 @@ LoopInclusionTreeNodeBase* LoopInclusionTreeNodeBase::findRoot(Optional<int> dep
     return root;
 }
 
-unsigned int LoopInclusionTreeNode::longestPathLengthToRoot()
+unsigned int LoopInclusionTreeNode::longestPathLengthToRoot() const
 {
-    if (this->getNeighbors().size() == 0) {
+    if(this->getNeighbors().size() == 0)
+    {
         // this is root
         return 0;
-
     }
 
     int longestLength = 0;
@@ -610,12 +610,35 @@ unsigned int LoopInclusionTreeNode::longestPathLengthToRoot()
         if(!parent.second.includes)
         {
             int length = reinterpret_cast<LoopInclusionTreeNode*>(parent.first)->longestPathLengthToRoot() + 1;
-            if (length > longestLength) {
+            if(length > longestLength)
+            {
                 longestLength = length;
             }
         }
     }
     return longestLength;
+}
+
+bool LoopInclusionTreeNode::hasCFGNodeInChildren(const CFGNode* node) const
+{
+    for(auto& child : this->getNeighbors())
+    {
+        if(child.second.includes)
+        {
+            auto nodes = child.first->key;
+            auto found = std::find(nodes->begin(), nodes->end(), node);
+            if(found != nodes->end())
+            {
+                return true;
+            }
+            auto foundInChildren = reinterpret_cast<LoopInclusionTreeNode*>(child.first)->hasCFGNodeInChildren(node);
+            if(foundInChildren)
+            {
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
 std::string LoopInclusionTreeNode::dumpLabel() const

--- a/src/analysis/ControlFlowGraph.cpp
+++ b/src/analysis/ControlFlowGraph.cpp
@@ -583,6 +583,24 @@ FastAccessList<ControlFlowLoop> ControlFlowGraph::findLoopsHelperRecursively(con
 
 // LoopInclusionTreeNodeBase::LoopInclusionTreeNodeBase(const KeyType key) : Node(key) {}
 
+LoopInclusionTreeNode* castToTreeNode(LoopInclusionTreeNodeBase *base) {
+    auto* node = dynamic_cast<LoopInclusionTreeNode*>(base);
+    if (node == nullptr) {
+        throw CompilationError(
+                CompilationStep::OPTIMIZER, "Cannot downcast to LoopInclusionTreeNode.");
+    }
+    return node;
+}
+
+const LoopInclusionTreeNode* castToTreeNode(const LoopInclusionTreeNodeBase *base) {
+    auto* node = dynamic_cast<const LoopInclusionTreeNode*>(base);
+    if (node == nullptr) {
+        throw CompilationError(
+                CompilationStep::OPTIMIZER, "Cannot downcast to LoopInclusionTreeNode.");
+    }
+    return node;
+}
+
 LoopInclusionTreeNodeBase* LoopInclusionTreeNodeBase::findRoot(Optional<int> depth)
 {
     if(depth && depth.value() == 0)
@@ -590,7 +608,7 @@ LoopInclusionTreeNodeBase* LoopInclusionTreeNodeBase::findRoot(Optional<int> dep
         return this;
     }
 
-    auto* self = reinterpret_cast<LoopInclusionTreeNode*>(this);
+    auto* self = castToTreeNode(this);
     LoopInclusionTreeNodeBase* root = this;
     self->forAllIncomingEdges([&](LoopInclusionTreeNodeBase& parent, LoopInclusionTreeEdge&) -> bool {
         // The root node must be only one
@@ -603,7 +621,7 @@ LoopInclusionTreeNodeBase* LoopInclusionTreeNodeBase::findRoot(Optional<int> dep
 
 unsigned int LoopInclusionTreeNodeBase::longestPathLengthToRoot() const
 {
-    auto* self = reinterpret_cast<const LoopInclusionTreeNode*>(this);
+    auto* self = castToTreeNode(this);
 
     if(self->getEdgesSize() == 0)
     {
@@ -626,11 +644,11 @@ unsigned int LoopInclusionTreeNodeBase::longestPathLengthToRoot() const
 
 bool LoopInclusionTreeNodeBase::hasCFGNodeInChildren(const CFGNode* node) const
 {
-    auto* self = reinterpret_cast<const LoopInclusionTreeNode*>(this);
+    auto* self = castToTreeNode(this);
 
     bool found = false;
     self->forAllOutgoingEdges([&](const LoopInclusionTreeNodeBase& childBase, const LoopInclusionTreeEdge&) -> bool {
-        auto child = reinterpret_cast<const LoopInclusionTreeNode*>(&childBase);
+        auto* child = castToTreeNode(&childBase);
         auto nodes = child->key;
 
         auto targetNode = std::find(nodes->begin(), nodes->end(), node);
@@ -653,6 +671,8 @@ bool LoopInclusionTreeNodeBase::hasCFGNodeInChildren(const CFGNode* node) const
 
 std::string LoopInclusionTreeNodeBase::dumpLabel() const
 {
-    auto* self = reinterpret_cast<const LoopInclusionTreeNode*>(this);
+    auto* self = castToTreeNode(this);
     return (*self->key->rbegin())->key->getLabel()->to_string();
 }
+
+

--- a/src/analysis/ControlFlowGraph.cpp
+++ b/src/analysis/ControlFlowGraph.cpp
@@ -513,18 +513,20 @@ std::unique_ptr<ControlFlowGraph> ControlFlowGraph::createCFG(Method& method)
     return graph;
 }
 
-std::unique_ptr<ControlFlowGraph> ControlFlowGraph::clone() {
+std::unique_ptr<ControlFlowGraph> ControlFlowGraph::clone()
+{
     std::unique_ptr<ControlFlowGraph> graph(new ControlFlowGraph());
 
-    for(auto &node : nodes) {
-        auto &newNode = graph->getOrCreateNode(node.first);
+    for(auto& node : nodes)
+    {
+        auto& newNode = graph->getOrCreateNode(node.first);
         node.second.forAllIncomingEdges([&newNode, &graph](const CFGNode& source, const CFGEdge& edge) -> bool {
-                auto &newSource = graph->getOrCreateNode(source.key);
-                auto &newEdge = newSource.getOrCreateEdge(&newNode, CFGRelation{}).addInput(newSource);
-                newEdge.data.isImplicit.emplace(source.key, edge.data.isImplicit.at(source.key));
-                newEdge.data.predecessors.emplace(source.key, edge.data.predecessors.at(source.key));
-                return true;
-            });
+            auto& newSource = graph->getOrCreateNode(source.key);
+            auto& newEdge = newSource.getOrCreateEdge(&newNode, CFGRelation{}).addInput(newSource);
+            newEdge.data.isImplicit.emplace(source.key, edge.data.isImplicit.at(source.key));
+            newEdge.data.predecessors.emplace(source.key, edge.data.predecessors.at(source.key));
+            return true;
+        });
     }
 
     return graph;

--- a/src/analysis/ControlFlowGraph.cpp
+++ b/src/analysis/ControlFlowGraph.cpp
@@ -137,30 +137,11 @@ bool ControlFlowLoop::includes(const ControlFlowLoop& other) const
         auto thisItr = std::find_if(
             begin(), end(), [&](const CFGNode* node) { return node->key == otherItr->key; });
         if (thisItr == end()) {
-            return true;
+            return false;
         }
     }
 
-    return false;
-
-    /*
-    auto head = std::find_if(
-        this->begin(), this->end(), [&](const CFGNode* node) { return node->key == (*other.begin())->key; });
-    if(head == this->end())
-    {
-        return false;
-    }
-
-    auto thisItr = head;
-    auto otherItr = other.begin();
-    while(thisItr != this->end() && otherItr != other.end() && (*thisItr)->key == (*otherItr)->key)
-    {
-        ++thisItr;
-        ++otherItr;
-    }
-
-    return otherItr == other.end();
-    */
+    return true;
 }
 
 CFGNode& ControlFlowGraph::getStartOfControlFlow()
@@ -564,8 +545,6 @@ ControlFlowLoop ControlFlowGraph::findLoopsHelper(const CFGNode* node, FastMap<c
 FastAccessList<ControlFlowLoop> ControlFlowGraph::findLoopsHelperRecursively(const CFGNode* node,
     FastMap<const CFGNode*, int>& discoveryTimes, RandomModificationList<const CFGNode*>& stack, int& time)
 {
-    logging::debug() << "node = " << node->key->getLabel()->getLabel()->to_string() << logging::endl;
-
     // Initialize discovery time
     discoveryTimes[node] = ++time;
     stack.push_back(node);
@@ -593,8 +572,7 @@ FastAccessList<ControlFlowLoop> ControlFlowGraph::findLoopsHelperRecursively(con
 
             loops.emplace_back(std::move(loop));
         }
-        // If v is not visited yet, then recur for it
-        else if (node != v) /*if(discoveryTimes[v] < discoveryTimes[node])*/
+        else if (node != v)
         {
             auto subLoops = findLoopsHelperRecursively(v, discoveryTimes, stack, time);
             if(subLoops.size() >= 1)
@@ -605,8 +583,6 @@ FastAccessList<ControlFlowLoop> ControlFlowGraph::findLoopsHelperRecursively(con
     });
 
     stack.pop_back();
-
-    logging::debug() << "pop: " << node->key->getLabel()->getLabel()->to_string() << logging::endl;
 
     return loops;
 }
@@ -702,9 +678,7 @@ bool LoopInclusionTreeNodeBase::hasCFGNodeInChildren(const CFGNode* node) const
 std::string LoopInclusionTreeNodeBase::dumpLabel() const
 {
     auto* self = castToTreeNode(this);
-    std::stringstream ss;
-    ss << this;
-    return (*self->key->rbegin())->key->getLabel()->to_string() + " @ " + ss.str();
+    return (*self->key->rbegin())->key->getLabel()->to_string();
 }
 
 

--- a/src/analysis/ControlFlowGraph.cpp
+++ b/src/analysis/ControlFlowGraph.cpp
@@ -219,7 +219,7 @@ FastAccessList<ControlFlowLoop> ControlFlowGraph::findLoops(bool recursively)
     {
         if(discoveryTimes[node] == 0)
         {
-            if (recursively)
+            if(recursively)
             {
                 auto subLoops = findLoopsHelperRecursively(node, discoveryTimes, stack, time);
                 if(subLoops.size() >= 1)
@@ -534,10 +534,10 @@ ControlFlowLoop ControlFlowGraph::findLoopsHelper(const CFGNode* node, FastMap<c
     return loop;
 }
 
-FastAccessList<ControlFlowLoop> ControlFlowGraph::findLoopsHelperRecursively(const CFGNode* node, FastMap<const CFGNode*, int>& discoveryTimes,
-    RandomModificationList<const CFGNode*>& stack, int& time)
+FastAccessList<ControlFlowLoop> ControlFlowGraph::findLoopsHelperRecursively(const CFGNode* node,
+    FastMap<const CFGNode*, int>& discoveryTimes, RandomModificationList<const CFGNode*>& stack, int& time)
 {
-    // Initialize discovery time and low value
+    // Initialize discovery time
     discoveryTimes[node] = ++time;
     stack.push_back(node);
 
@@ -545,8 +545,7 @@ FastAccessList<ControlFlowLoop> ControlFlowGraph::findLoopsHelperRecursively(con
 
     // Go through all vertices adjacent to this
     node->forAllNeighbors(toFunction(&CFGRelation::isForwardRelation),
-        [this, node, &discoveryTimes, &stack, &time, &loops](
-            const CFGNode* next, const CFGRelation& rel) -> void {
+        [this, node, &discoveryTimes, &stack, &time, &loops](const CFGNode* next, const CFGRelation& rel) -> void {
             const CFGNode* v = next;
             // If v is not visited yet, then recur for it
             if(discoveryTimes[v] == 0)
@@ -556,15 +555,13 @@ FastAccessList<ControlFlowLoop> ControlFlowGraph::findLoopsHelperRecursively(con
                     loops.insert(loops.end(), subLoops.begin(), subLoops.end());
             }
 
-            // Update low value of 'u' only of 'v' is still in stack
-            // (i.e. it's a back edge, not cross edge).
-            // Case 2 (per above discussion on Disc and Low value)
+            // Create a loop including 'v' only of 'v' is still in stack
             else if(std::find(stack.begin(), stack.end(), v) != stack.end() && node != v)
             {
                 ControlFlowLoop loop;
                 RandomModificationList<const CFGNode*> tempStack = stack;
 
-                while (tempStack.back() != v)
+                while(tempStack.back() != v)
                 {
                     loop.push_back(tempStack.back());
                     tempStack.pop_back();

--- a/src/analysis/ControlFlowGraph.cpp
+++ b/src/analysis/ControlFlowGraph.cpp
@@ -626,7 +626,7 @@ FastAccessList<ControlFlowLoop> ControlFlowGraph::findLoopsHelperRecursively(con
 
 // LoopInclusionTreeNodeBase::LoopInclusionTreeNodeBase(const KeyType key) : Node(key) {}
 
-LoopInclusionTreeNode* castToTreeNode(LoopInclusionTreeNodeBase* base)
+LoopInclusionTreeNode* vc4c::castToTreeNode(LoopInclusionTreeNodeBase* base)
 {
     auto* node = dynamic_cast<LoopInclusionTreeNode*>(base);
     if(node == nullptr)
@@ -636,7 +636,7 @@ LoopInclusionTreeNode* castToTreeNode(LoopInclusionTreeNodeBase* base)
     return node;
 }
 
-const LoopInclusionTreeNode* castToTreeNode(const LoopInclusionTreeNodeBase* base)
+const LoopInclusionTreeNode* vc4c::castToTreeNode(const LoopInclusionTreeNodeBase* base)
 {
     auto* node = dynamic_cast<const LoopInclusionTreeNode*>(base);
     if(node == nullptr)

--- a/src/analysis/ControlFlowGraph.cpp
+++ b/src/analysis/ControlFlowGraph.cpp
@@ -523,7 +523,6 @@ std::unique_ptr<ControlFlowGraph> ControlFlowGraph::clone()
         node.second.forAllIncomingEdges([&newNode, &graph](const CFGNode& source, const CFGEdge& edge) -> bool {
             auto& newSource = graph->getOrCreateNode(source.key);
             auto& newEdge = newSource.getOrCreateEdge(&newNode, CFGRelation{}).addInput(newSource);
-            newEdge.data.isImplicit.emplace(source.key, edge.data.isImplicit.at(source.key));
             newEdge.data.predecessors.emplace(source.key, edge.data.predecessors.at(source.key));
             return true;
         });
@@ -581,7 +580,7 @@ ControlFlowLoop ControlFlowGraph::findLoopsHelper(const CFGNode* node, FastMap<c
 }
 
 FastAccessList<ControlFlowLoop> ControlFlowGraph::findLoopsHelperRecursively(const CFGNode* node,
-    FastMap<const CFGNode*, int>& discoveryTimes, RandomModificationList<const CFGNode*>& stack, int& time)
+    FastMap<const CFGNode*, int>& discoveryTimes, FastModificationList<const CFGNode*>& stack, int& time)
 {
     // Initialize discovery time
     discoveryTimes[node] = ++time;
@@ -598,7 +597,7 @@ FastAccessList<ControlFlowLoop> ControlFlowGraph::findLoopsHelperRecursively(con
             if(std::find(stack.begin(), stack.end(), v) != stack.end() && node != v)
             {
                 ControlFlowLoop loop;
-                RandomModificationList<const CFGNode*> tempStack = stack;
+                FastModificationList<const CFGNode*> tempStack = stack;
 
                 while(tempStack.back() != v)
                 {

--- a/src/analysis/ControlFlowGraph.cpp
+++ b/src/analysis/ControlFlowGraph.cpp
@@ -95,6 +95,22 @@ const CFGNode* ControlFlowLoop::findPredecessor() const
     return predecessor;
 }
 
+FastAccessList<const CFGNode*> ControlFlowLoop::findPredecessors() const
+{
+    FastAccessList<const CFGNode*> predecessors;
+    for(const CFGNode* node : *this)
+    {
+        node->forAllIncomingEdges([this, &predecessors](const CFGNode& neighbor, const CFGEdge& edge) -> bool {
+            if(std::find(begin(), end(), &neighbor) == end())
+            {
+                predecessors.push_back(&neighbor);
+            }
+            return true;
+        });
+    }
+    return predecessors;
+}
+
 const CFGNode* ControlFlowLoop::findSuccessor() const
 {
     const CFGNode* successor = nullptr;

--- a/src/analysis/ControlFlowGraph.cpp
+++ b/src/analysis/ControlFlowGraph.cpp
@@ -515,7 +515,7 @@ std::unique_ptr<ControlFlowGraph> ControlFlowGraph::createCFG(Method& method)
 
 std::unique_ptr<ControlFlowGraph> ControlFlowGraph::clone()
 {
-    std::unique_ptr<ControlFlowGraph> graph(new ControlFlowGraph());
+    std::unique_ptr<ControlFlowGraph> graph(new ControlFlowGraph(nodes.size()));
 
     for(auto& node : nodes)
     {
@@ -659,7 +659,7 @@ LoopInclusionTreeNodeBase* LoopInclusionTreeNodeBase::findRoot(Optional<int> dep
     self->forAllIncomingEdges([&](LoopInclusionTreeNodeBase& parent, LoopInclusionTreeEdge&) -> bool {
         // The root node must be only one
         std::function<int(const int&)> dec = [](const int& d) -> int { return d - 1; };
-        root = parent.findRoot(depth.map(dec));
+        root = parent.findRoot(depth.ifPresent(dec));
         return true;
     });
     return root;

--- a/src/analysis/ControlFlowGraph.h
+++ b/src/analysis/ControlFlowGraph.h
@@ -22,6 +22,9 @@ namespace vc4c
     class CFGRelation
     {
     public:
+        // this is used for only optimizations::removeConstantLoadInLoops
+        bool isBackEdge = false;
+
         // map of the source block and the implicit flags
         // std::map<BasicBlock*, bool> isImplicit;
 
@@ -43,9 +46,6 @@ namespace vc4c
     private:
         // map of the source block and the predecessor within this block (empty for fall-through)
         std::map<BasicBlock*, Optional<InstructionWalker>> predecessors;
-
-        // this is used for only optimizations::removeConstantLoadInLoops
-        bool isBackEdge = false;
 
         friend class ControlFlowGraph;
     };
@@ -152,7 +152,7 @@ namespace vc4c
          * This is similar to findLoopsHelper, but this finds also nested loops excluding one-block-loop.
          */
         FastAccessList<ControlFlowLoop> findLoopsHelperRecursively(const CFGNode* node,
-            FastMap<const CFGNode*, int>& discoveryTimes, RandomModificationList<const CFGNode*>& stack, int& time);
+            FastMap<const CFGNode*, int>& discoveryTimes, FastModificationList<const CFGNode*>& stack, int& time);
 
         friend class Method;
     };

--- a/src/analysis/ControlFlowGraph.h
+++ b/src/analysis/ControlFlowGraph.h
@@ -62,7 +62,7 @@ namespace vc4c
      */
     struct ControlFlowLoop : public FastAccessList<const CFGNode*>
     {
-        ControlFlowLoop() {}
+        ControlFlowLoop() = default;
 
         /*
          * Returns the basic-block(s) in the CFG preceding the first node in the loop, the node from which the loop is

--- a/src/analysis/ControlFlowGraph.h
+++ b/src/analysis/ControlFlowGraph.h
@@ -22,6 +22,9 @@ namespace vc4c
     class CFGRelation
     {
     public:
+        // map of the source block and the implicit flags
+        // std::map<BasicBlock*, bool> isImplicit;
+
         bool operator==(const CFGRelation& other) const;
 
         std::string getLabel() const;
@@ -40,6 +43,9 @@ namespace vc4c
     private:
         // map of the source block and the predecessor within this block (empty for fall-through)
         std::map<BasicBlock*, Optional<InstructionWalker>> predecessors;
+
+        // this is used for only optimizations::removeConstantLoadInLoops
+        bool isBackEdge = false;
 
         friend class ControlFlowGraph;
     };
@@ -117,6 +123,15 @@ namespace vc4c
         void updateOnBranchInsertion(Method& method, InstructionWalker it);
         void updateOnBranchRemoval(Method& method, BasicBlock& affectedBlock, const Local* branchTarget);
 
+        /*
+         * Creates the CFG from the basic-blocks within the given method
+         */
+        static std::unique_ptr<ControlFlowGraph> createCFG(Method& method);
+
+        /*
+         * Clone the CFG
+         */
+        std::unique_ptr<ControlFlowGraph> clone();
     private:
         explicit ControlFlowGraph(std::size_t numBlocks) : Graph(numBlocks) {}
         /*
@@ -137,11 +152,6 @@ namespace vc4c
          */
         FastAccessList<ControlFlowLoop> findLoopsHelperRecursively(const CFGNode* node,
             FastMap<const CFGNode*, int>& discoveryTimes, RandomModificationList<const CFGNode*>& stack, int& time);
-
-        /*
-         * Creates the CFG from the basic-blocks within the given method
-         */
-        static std::unique_ptr<ControlFlowGraph> createCFG(Method& method);
 
         friend class Method;
     };

--- a/src/analysis/ControlFlowGraph.h
+++ b/src/analysis/ControlFlowGraph.h
@@ -138,13 +138,15 @@ namespace vc4c
          * subtree rooted with current node stack --> To store all the connected ancestors (could be part of SCC)
          */
         ControlFlowLoop findLoopsHelper(const CFGNode* node, FastMap<const CFGNode*, int>& discoveryTimes,
-            FastMap<const CFGNode*, int>& lowestReachable, FastModificationList<const CFGNode*>& stack, int& time, unsigned idBase);
+            FastMap<const CFGNode*, int>& lowestReachable, FastModificationList<const CFGNode*>& stack, int& time,
+            unsigned idBase);
 
         /*
          * This is similar to findLoopsHelper, but this finds also nested loops excluding one-block-loop.
          */
         FastAccessList<ControlFlowLoop> findLoopsHelperRecursively(const CFGNode* node,
-            FastMap<const CFGNode*, int>& discoveryTimes, RandomModificationList<const CFGNode*>& stack, int& time, unsigned idBase);
+            FastMap<const CFGNode*, int>& discoveryTimes, RandomModificationList<const CFGNode*>& stack, int& time,
+            unsigned idBase);
 
         /*
          * Creates the CFG from the basic-blocks within the given method

--- a/src/analysis/ControlFlowGraph.h
+++ b/src/analysis/ControlFlowGraph.h
@@ -154,7 +154,6 @@ namespace vc4c
 
     struct LoopInclusionTreeNodeBase
     {
-        // LoopInclusionTreeNodeBase(const KeyType key);
         virtual ~LoopInclusionTreeNodeBase() = default;
 
         LoopInclusionTreeNodeBase* findRoot(Optional<int> depth);

--- a/src/analysis/ControlFlowGraph.h
+++ b/src/analysis/ControlFlowGraph.h
@@ -109,7 +109,7 @@ namespace vc4c
         /*
          * Dump this graph as dot file
          */
-        void dumpGraph(const std::string& path, bool dumpInstructions) const;
+        void dumpGraph(const std::string& path, bool dumpConstantLoadInstructions) const;
 
         void updateOnBlockInsertion(Method& method, BasicBlock& newBlock);
         void updateOnBlockRemoval(Method& method, BasicBlock& oldBlock);

--- a/src/analysis/ControlFlowGraph.h
+++ b/src/analysis/ControlFlowGraph.h
@@ -153,8 +153,10 @@ namespace vc4c
     struct LoopInclusionTreeNodeBase
     {
         LoopInclusionTreeNodeBase(const KeyType key);
+
         LoopInclusionTreeNodeBase* findRoot(Optional<int> depth);
-        unsigned int longestPathLengthToRoot();
+        unsigned int longestPathLengthToRoot() const;
+        bool hasCFGNodeInChildren(const CFGNode* node) const;
 
         std::string dumpLabel() const;
     };

--- a/src/analysis/ControlFlowGraph.h
+++ b/src/analysis/ControlFlowGraph.h
@@ -176,9 +176,8 @@ namespace vc4c
         Node<ControlFlowLoop*, LoopInclusion, Directionality::DIRECTED, LoopInclusionTreeNodeBase>;
     using LoopInclusionTreeEdge = LoopInclusionTreeNode::EdgeType;
 
-    // Cannot expose these functions due to link error.(?)
-    // LoopInclusionTreeNode* castToTreeNode(LoopInclusionTreeNodeBase *base);
-    // const LoopInclusionTreeNode* castToTreeNode(const LoopInclusionTreeNodeBase *base);
+    LoopInclusionTreeNode* castToTreeNode(LoopInclusionTreeNodeBase* base);
+    const LoopInclusionTreeNode* castToTreeNode(const LoopInclusionTreeNodeBase* base);
 
     /*
      * The trees represents inclusion relation of control-flow loops. This may have multiple trees.

--- a/src/analysis/ControlFlowGraph.h
+++ b/src/analysis/ControlFlowGraph.h
@@ -56,7 +56,7 @@ namespace vc4c
      */
     struct ControlFlowLoop : public FastAccessList<const CFGNode*>
     {
-        ControlFlowLoop(unsigned id) : id(id) {}
+        ControlFlowLoop() {}
 
         /*
          * Returns the basic-block in the CFG preceding the first node in the loop, the node from which the loop is
@@ -79,15 +79,6 @@ namespace vc4c
          * Returns whether this loop includes other loop and doesn't equal it.
          */
         bool includes(const ControlFlowLoop& other) const;
-
-        unsigned getID() const
-        {
-            return id;
-        }
-
-    private:
-        // to identify loop at optimizations::removeConstantLoadInLoops
-        unsigned id;
     };
 
     /*
@@ -118,7 +109,7 @@ namespace vc4c
         /*
          * Dump this graph as dot file
          */
-        void dumpGraph(const std::string& path) const;
+        void dumpGraph(const std::string& path, bool dumpInstructions) const;
 
         void updateOnBlockInsertion(Method& method, BasicBlock& newBlock);
         void updateOnBlockRemoval(Method& method, BasicBlock& oldBlock);
@@ -138,15 +129,13 @@ namespace vc4c
          * subtree rooted with current node stack --> To store all the connected ancestors (could be part of SCC)
          */
         ControlFlowLoop findLoopsHelper(const CFGNode* node, FastMap<const CFGNode*, int>& discoveryTimes,
-            FastMap<const CFGNode*, int>& lowestReachable, FastModificationList<const CFGNode*>& stack, int& time,
-            unsigned idBase);
+            FastMap<const CFGNode*, int>& lowestReachable, FastModificationList<const CFGNode*>& stack, int& time);
 
         /*
          * This is similar to findLoopsHelper, but this finds also nested loops excluding one-block-loop.
          */
         FastAccessList<ControlFlowLoop> findLoopsHelperRecursively(const CFGNode* node,
-            FastMap<const CFGNode*, int>& discoveryTimes, RandomModificationList<const CFGNode*>& stack, int& time,
-            unsigned idBase);
+            FastMap<const CFGNode*, int>& discoveryTimes, RandomModificationList<const CFGNode*>& stack, int& time);
 
         /*
          * Creates the CFG from the basic-blocks within the given method

--- a/src/analysis/ControlFlowGraph.h
+++ b/src/analysis/ControlFlowGraph.h
@@ -166,6 +166,7 @@ namespace vc4c
     struct LoopInclusionTreeNodeBase
     {
         // LoopInclusionTreeNodeBase(const KeyType key);
+        virtual ~LoopInclusionTreeNodeBase() = default;
 
         LoopInclusionTreeNodeBase* findRoot(Optional<int> depth);
         unsigned int longestPathLengthToRoot() const;
@@ -177,6 +178,10 @@ namespace vc4c
     using LoopInclusionTreeNode =
         Node<ControlFlowLoop*, LoopInclusion, Directionality::DIRECTED, LoopInclusionTreeNodeBase>;
     using LoopInclusionTreeEdge = LoopInclusionTreeNode::EdgeType;
+
+    // Cannot expose these functions due to link error.(?)
+    // LoopInclusionTreeNode* castToTreeNode(LoopInclusionTreeNodeBase *base);
+    // const LoopInclusionTreeNode* castToTreeNode(const LoopInclusionTreeNodeBase *base);
 
     /*
      * The trees represents inclusion relation of control-flow loops. This may have multiple trees.

--- a/src/analysis/ControlFlowGraph.h
+++ b/src/analysis/ControlFlowGraph.h
@@ -152,7 +152,11 @@ namespace vc4c
 
     struct LoopInclusionTreeNodeBase
     {
-        LoopInclusionTreeNodeBase* findRoot();
+        LoopInclusionTreeNodeBase(const KeyType key);
+        LoopInclusionTreeNodeBase* findRoot(Optional<int> depth);
+        unsigned int longestPathLengthToRoot();
+
+        std::string dumpLabel() const;
     };
 
     using LoopInclusionTreeNode =

--- a/src/analysis/ControlFlowGraph.h
+++ b/src/analysis/ControlFlowGraph.h
@@ -132,6 +132,7 @@ namespace vc4c
          * Clone the CFG
          */
         std::unique_ptr<ControlFlowGraph> clone();
+
     private:
         explicit ControlFlowGraph(std::size_t numBlocks) : Graph(numBlocks) {}
         /*

--- a/src/analysis/ControlFlowGraph.h
+++ b/src/analysis/ControlFlowGraph.h
@@ -25,9 +25,6 @@ namespace vc4c
         // this is used for only optimizations::removeConstantLoadInLoops
         bool isBackEdge = false;
 
-        // map of the source block and the implicit flags
-        // std::map<BasicBlock*, bool> isImplicit;
-
         bool operator==(const CFGRelation& other) const;
 
         std::string getLabel() const;

--- a/src/analysis/ControlFlowGraph.h
+++ b/src/analysis/ControlFlowGraph.h
@@ -102,7 +102,7 @@ namespace vc4c
         /*
          * Finds all loops in the CFG
          */
-        FastAccessList<ControlFlowLoop> findLoops();
+        FastAccessList<ControlFlowLoop> findLoops(bool recursively);
 
         /*
          * Dump this graph as dot file
@@ -128,6 +128,12 @@ namespace vc4c
          */
         ControlFlowLoop findLoopsHelper(const CFGNode* node, FastMap<const CFGNode*, int>& discoveryTimes,
             FastMap<const CFGNode*, int>& lowestReachable, FastModificationList<const CFGNode*>& stack, int& time);
+
+        /*
+         * This is similar to findLoopsHelper, but this finds also nested loops excluding one-block-loop.
+         */
+        FastAccessList<ControlFlowLoop> findLoopsHelperRecursively(const CFGNode* node, FastMap<const CFGNode*, int>& discoveryTimes,
+            RandomModificationList<const CFGNode*>& stack, int& time);
 
         /*
          * Creates the CFG from the basic-blocks within the given method

--- a/src/analysis/ControlFlowGraph.h
+++ b/src/analysis/ControlFlowGraph.h
@@ -56,6 +56,8 @@ namespace vc4c
      */
     struct ControlFlowLoop : public FastAccessList<const CFGNode*>
     {
+        ControlFlowLoop(unsigned id) : id(id) {}
+
         /*
          * Returns the basic-block in the CFG preceding the first node in the loop, the node from which the loop is
          * entered.
@@ -77,6 +79,15 @@ namespace vc4c
          * Returns whether this loop includes other loop and doesn't equal it.
          */
         bool includes(const ControlFlowLoop& other) const;
+
+        unsigned getID() const
+        {
+            return id;
+        }
+
+    private:
+        // to identify loop at optimizations::removeConstantLoadInLoops
+        unsigned id;
     };
 
     /*
@@ -127,13 +138,13 @@ namespace vc4c
          * subtree rooted with current node stack --> To store all the connected ancestors (could be part of SCC)
          */
         ControlFlowLoop findLoopsHelper(const CFGNode* node, FastMap<const CFGNode*, int>& discoveryTimes,
-            FastMap<const CFGNode*, int>& lowestReachable, FastModificationList<const CFGNode*>& stack, int& time);
+            FastMap<const CFGNode*, int>& lowestReachable, FastModificationList<const CFGNode*>& stack, int& time, unsigned idBase);
 
         /*
          * This is similar to findLoopsHelper, but this finds also nested loops excluding one-block-loop.
          */
         FastAccessList<ControlFlowLoop> findLoopsHelperRecursively(const CFGNode* node,
-            FastMap<const CFGNode*, int>& discoveryTimes, RandomModificationList<const CFGNode*>& stack, int& time);
+            FastMap<const CFGNode*, int>& discoveryTimes, RandomModificationList<const CFGNode*>& stack, int& time, unsigned idBase);
 
         /*
          * Creates the CFG from the basic-blocks within the given method

--- a/src/analysis/ControlFlowGraph.h
+++ b/src/analysis/ControlFlowGraph.h
@@ -59,10 +59,11 @@ namespace vc4c
         ControlFlowLoop() {}
 
         /*
-         * Returns the basic-block in the CFG preceding the first node in the loop, the node from which the loop is
+         * Returns the basic-block(s) in the CFG preceding the first node in the loop, the node from which the loop is
          * entered.
          */
         const CFGNode* findPredecessor() const;
+        FastAccessList<const CFGNode*> findPredecessors() const;
 
         /*
          * Returns the basic-block in the CFG following the last node in the loop, the node into which this loop exits

--- a/src/analysis/ControlFlowGraph.h
+++ b/src/analysis/ControlFlowGraph.h
@@ -132,8 +132,8 @@ namespace vc4c
         /*
          * This is similar to findLoopsHelper, but this finds also nested loops excluding one-block-loop.
          */
-        FastAccessList<ControlFlowLoop> findLoopsHelperRecursively(const CFGNode* node, FastMap<const CFGNode*, int>& discoveryTimes,
-            RandomModificationList<const CFGNode*>& stack, int& time);
+        FastAccessList<ControlFlowLoop> findLoopsHelperRecursively(const CFGNode* node,
+            FastMap<const CFGNode*, int>& discoveryTimes, RandomModificationList<const CFGNode*>& stack, int& time);
 
         /*
          * Creates the CFG from the basic-blocks within the given method

--- a/src/analysis/ControlFlowGraph.h
+++ b/src/analysis/ControlFlowGraph.h
@@ -152,7 +152,7 @@ namespace vc4c
 
     struct LoopInclusionTreeNodeBase
     {
-        LoopInclusionTreeNodeBase(const KeyType key);
+        // LoopInclusionTreeNodeBase(const KeyType key);
 
         LoopInclusionTreeNodeBase* findRoot(Optional<int> depth);
         unsigned int longestPathLengthToRoot() const;

--- a/src/analysis/DebugGraph.cpp
+++ b/src/analysis/DebugGraph.cpp
@@ -57,7 +57,7 @@ void vc4c::printEdge(
 
 void vc4c::printNode(std::ofstream& file, uintptr_t ID, const std::string& name)
 {
-    file << ID << " [label=" << cleanName(name) << "];" << std::endl;
+    file << ID << " [label=" << cleanName(name) << ", shape=\"box\"];" << std::endl;
 }
 LCOV_EXCL_STOP
 #endif

--- a/src/intermediate/Instruction.cpp
+++ b/src/intermediate/Instruction.cpp
@@ -460,13 +460,7 @@ bool IntermediateInstruction::replaceValue(const Value& oldValue, const Value& n
 
 bool IntermediateInstruction::isConstantInstruction() const
 {
-    if(dynamic_cast<const LoadImmediate*>(this) != nullptr)
-    {
-        return true;
-    }
-    auto& args = getArguments();
-    return std::all_of(args.begin(), args.end(), [](const Value& arg) { return !arg.isWriteable(); }) &&
-        getOutput().has_value() && !hasSideEffects() && !hasConditionalExecution() &&
+    return precalculate(1).has_value() && !hasSideEffects() && !hasConditionalExecution() &&
         !hasDecoration(InstructionDecorations::PHI_NODE);
 }
 

--- a/src/intermediate/Instruction.cpp
+++ b/src/intermediate/Instruction.cpp
@@ -460,11 +460,11 @@ bool IntermediateInstruction::replaceValue(const Value& oldValue, const Value& n
 
 bool IntermediateInstruction::isConstantInstruction() const
 {
-    return dynamic_cast<const intermediate::BranchLabel*>(this) == nullptr && precalculate(1).has_value() &&
+    return dynamic_cast<const intermediate::BranchLabel*>(this) == nullptr && precalculate(1).first.has_value() &&
         !hasSideEffects() && !hasConditionalExecution() && !hasDecoration(InstructionDecorations::PHI_NODE);
 }
 
-bool IntermediateInstruction::readsRegister(Register& reg) const
+bool IntermediateInstruction::readsRegister(Register reg) const
 {
     for(const Value& arg : arguments)
         if(arg.hasRegister(reg))

--- a/src/intermediate/Instruction.cpp
+++ b/src/intermediate/Instruction.cpp
@@ -460,8 +460,8 @@ bool IntermediateInstruction::replaceValue(const Value& oldValue, const Value& n
 
 bool IntermediateInstruction::isConstantInstruction() const
 {
-    return precalculate(1).has_value() && !hasSideEffects() && !hasConditionalExecution() &&
-        !hasDecoration(InstructionDecorations::PHI_NODE);
+    return dynamic_cast<const intermediate::BranchLabel*>(this) == nullptr && precalculate(1).has_value() &&
+        !hasSideEffects() && !hasConditionalExecution() && !hasDecoration(InstructionDecorations::PHI_NODE);
 }
 
 bool IntermediateInstruction::readsRegister(Register& reg) const

--- a/src/intermediate/Instruction.cpp
+++ b/src/intermediate/Instruction.cpp
@@ -458,7 +458,19 @@ bool IntermediateInstruction::replaceValue(const Value& oldValue, const Value& n
     return replaced;
 }
 
-bool IntermediateInstruction::readsRegister(Register reg) const
+bool IntermediateInstruction::isConstantInstruction() const
+{
+    if(dynamic_cast<const LoadImmediate*>(this) != nullptr)
+    {
+        return true;
+    }
+    auto& args = getArguments();
+    return std::all_of(args.begin(), args.end(), [](const Value& arg) { return !arg.isWriteable(); }) &&
+        getOutput().has_value() && !hasSideEffects() && !hasConditionalExecution() &&
+        !hasDecoration(InstructionDecorations::PHI_NODE);
+}
+
+bool IntermediateInstruction::readsRegister(Register& reg) const
 {
     for(const Value& arg : arguments)
         if(arg.hasRegister(reg))

--- a/src/intermediate/IntermediateInstruction.h
+++ b/src/intermediate/IntermediateInstruction.h
@@ -241,7 +241,8 @@ namespace vc4c
 
             /* Determine constant instruction, such as
              * - load immediate instruction
-             * - instruction whose all arguments are immediate value and which has output without side effect (its result is immediate)
+             * - instruction whose all arguments are immediate value and which has output without side effect (its
+             * result is immediate)
              */
             bool isConstantInstruction() const;
 

--- a/src/intermediate/IntermediateInstruction.h
+++ b/src/intermediate/IntermediateInstruction.h
@@ -239,6 +239,12 @@ namespace vc4c
 
             bool replaceValue(const Value& oldValue, const Value& newValue, LocalUse::Type type);
 
+            /* Determine constant instruction, such as
+             * - load immediate instruction
+             * - instruction whose all arguments are immediate value and which has output without side effect (its result is immediate)
+             */
+            bool isConstantInstruction() const;
+
             Signaling signal;
             Unpack unpackMode;
             Pack packMode;

--- a/src/optimization/ControlFlow.cpp
+++ b/src/optimization/ControlFlow.cpp
@@ -1439,9 +1439,9 @@ bool optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
     {
         auto& node = inclusionTree.getOrCreateNode(loop.first);
         auto root = dynamic_cast<LoopInclusionTreeNode*>(node.findRoot({}));
-        if (root == nullptr) {
-            throw CompilationError(
-                    CompilationStep::OPTIMIZER, "Cannot downcast to LoopInclusionTreeNode.");
+        if(root == nullptr)
+        {
+            throw CompilationError(CompilationStep::OPTIMIZER, "Cannot downcast to LoopInclusionTreeNode.");
         }
 
         if(processed.find(root) != processed.end())
@@ -1457,22 +1457,24 @@ bool optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
             auto currentNode = que.front();
             que.pop();
 
-            auto targetTreeNode = dynamic_cast<LoopInclusionTreeNode*>(currentNode->findRoot(moveDepth == -1 ? Optional<int>() : Optional<int>(moveDepth - 1)));
-            if (targetTreeNode == nullptr) {
-                throw CompilationError(
-                        CompilationStep::OPTIMIZER, "Cannot downcast to LoopInclusionTreeNode.");
+            auto targetTreeNode = dynamic_cast<LoopInclusionTreeNode*>(
+                currentNode->findRoot(moveDepth == -1 ? Optional<int>() : Optional<int>(moveDepth - 1)));
+            if(targetTreeNode == nullptr)
+            {
+                throw CompilationError(CompilationStep::OPTIMIZER, "Cannot downcast to LoopInclusionTreeNode.");
             }
             auto targetLoop = targetTreeNode->key;
 
             currentNode->forAllOutgoingEdges(
-                    [&](const LoopInclusionTreeNode& child, const LoopInclusionTreeEdge&) -> bool {
+                [&](const LoopInclusionTreeNode& child, const LoopInclusionTreeEdge&) -> bool {
                     que.push(const_cast<LoopInclusionTreeNode*>(&child));
                     return true;
-                    });
+                });
 
             auto insts = instMapper.find(currentNode);
-            if (insts == instMapper.end()) {
-              continue;
+            if(insts == instMapper.end())
+            {
+                continue;
             }
 
             auto targetCFGNode = targetLoop->findPredecessor();
@@ -1481,23 +1483,22 @@ bool optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
             if(targetBlock != nullptr)
             {
                 // insert before 'br' operation
-                auto &targetInst = targetBlock->end().previousInBlock();
-                for (auto it : insts->second) {
-
+                auto& targetInst = targetBlock->end().previousInBlock();
+                for(auto it : insts->second)
+                {
                     targetInst.emplace(it.release());
                     it.erase();
                 }
             }
             else
             {
-                logging::debug()
-                    << "Create a new basic block before the target block" << logging::endl;
+                logging::debug() << "Create a new basic block before the target block" << logging::endl;
 
                 auto headBlock = method.begin();
 
-                insertedBlock = &method.createAndInsertNewBlock(
-                        method.begin(), "%createdByRemoveConstantLoadInLoops");
-                for (auto it : insts->second) {
+                insertedBlock = &method.createAndInsertNewBlock(method.begin(), "%createdByRemoveConstantLoadInLoops");
+                for(auto it : insts->second)
+                {
                     insertedBlock->end().emplace(it.release());
                     it.erase();
                 }
@@ -1505,8 +1506,7 @@ bool optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
                 if(headBlock->getLabel()->getLabel()->name == BasicBlock::DEFAULT_BLOCK)
                 {
                     // swap labels because DEFAULT_BLOCK is treated as head block.
-                    headBlock->getLabel()->getLabel()->name.swap(
-                            insertedBlock->getLabel()->getLabel()->name);
+                    headBlock->getLabel()->getLabel()->name.swap(insertedBlock->getLabel()->getLabel()->name);
                 }
             }
         }

--- a/src/optimization/ControlFlow.cpp
+++ b/src/optimization/ControlFlow.cpp
@@ -972,7 +972,7 @@ bool optimizations::vectorizeLoops(const Module& module, Method& method, const C
 {
     // 1. find loops
     auto& cfg = method.getCFG();
-    auto loops = cfg.findLoops();
+    auto loops = cfg.findLoops(false);
     bool hasChanged = false;
 
     // 2. determine data dependencies of loop bodies
@@ -1335,7 +1335,8 @@ bool optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
 
     // 1. find loops
     auto& cfg = method.getCFG();
-    auto loops = cfg.findLoops();
+    cfg.dumpGraph("a.dot");
+    auto loops = cfg.findLoops(true);
 
     // 2. generate inclusion relation of loops as trees
     LoopInclusionTree inclusionTree;
@@ -1352,13 +1353,13 @@ bool optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
         }
     }
 
-    // logging::debug() << "inclusionTree" << logging::endl;
-    // for(auto& loop : inclusionTree) {
-    //     logging::debug() << "  " << loop.first << logging::endl;
-    //     for(auto& node : loop.second.getNeighbors()) {
-    //         logging::debug() << "    " << node.first->key << ": " << node.second.includes << logging::endl;
-    //     }
-    // }
+    logging::debug() << "inclusionTree" << logging::endl;
+    for(auto& loop : inclusionTree) {
+        logging::debug() << "  " << loop.first << logging::endl;
+        for(auto& node : loop.second.getNeighbors()) {
+            logging::debug() << "    " << node.first->key << ": " << node.second.includes << logging::endl;
+        }
+    }
 
     // 3. move constant load operations from root of trees
     FastSet<ControlFlowLoop*> processed;

--- a/src/optimization/ControlFlow.cpp
+++ b/src/optimization/ControlFlow.cpp
@@ -1420,13 +1420,9 @@ bool optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
             {
                 if(it->isConstantInstruction())
                 {
-                    auto out = it->getOutput().value();
-                    if(out.hasType(ValueType::LOCAL))
-                    {
-                        instMapper[&node].push_back(it);
+                    instMapper[&node].push_back(it);
 
-                        hasChanged = true;
-                    }
+                    hasChanged = true;
                 }
             }
         }

--- a/src/optimization/ControlFlow.cpp
+++ b/src/optimization/ControlFlow.cpp
@@ -1413,14 +1413,22 @@ bool optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
         {
             logging::debug() << "  longest node: " << longestNode->dumpLabel() << logging::endl;
 
+            std::vector<LoopInclusionTreeNode*> nonConnectedEdges;
+
             currentNode.forAllIncomingEdges([&](LoopInclusionTreeNode& other, LoopInclusionTreeEdge&) -> bool {
                 auto otherNode = &other;
                 if(longestNode != otherNode)
                 {
-                    otherNode->removeAsNeighbor(&currentNode);
+                    // To avoid finishing loop
+                    nonConnectedEdges.push_back(otherNode);
                 }
                 return true;
             });
+
+            for (auto &otherNode : nonConnectedEdges) {
+                otherNode->removeAsNeighbor(&currentNode);
+                logging::debug() << "  remove node: " << otherNode->dumpLabel() << logging::endl;
+            }
         }
     }
 

--- a/src/optimization/ControlFlow.cpp
+++ b/src/optimization/ControlFlow.cpp
@@ -1433,6 +1433,12 @@ bool optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
                 return false;
             });
 
+            if(prev == nullptr || next == nullptr)
+            {
+                throw CompilationError(
+                    CompilationStep::OPTIMIZER, "A unnecessary node must has just a previous node and a next node.");
+            }
+
             cfg->eraseNode(node->key);
             if(!prev->isAdjacent(next))
             {

--- a/src/optimization/ControlFlow.cpp
+++ b/src/optimization/ControlFlow.cpp
@@ -1448,6 +1448,13 @@ bool optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
     // 2. Find loops
     auto loops = cfg->findLoops(true);
 
+    // FIXME: Skip this optimization because it takes so long time with many loops.
+    if(loops.size() > 100000)
+    {
+        logging::warn() << "Skip this optimization due to many nodes in loops." << logging::endl;
+        return false;
+    }
+
     // 3. Generate inclusion relation of loops as trees
     // e.g.
     //

--- a/src/optimization/ControlFlow.cpp
+++ b/src/optimization/ControlFlow.cpp
@@ -1319,7 +1319,9 @@ bool optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
 
     // 1. find loops
     auto& cfg = method.getCFG();
-    // cfg.dumpGraph("before-removeConstantLoadInLoops.dot", true);
+#ifdef DEBUG_MODE
+    cfg.dumpGraph("before-removeConstantLoadInLoops.dot", true);
+#endif
     auto loops = cfg.findLoops(true);
 
     // 2. generate inclusion relation of loops as trees
@@ -1508,8 +1510,10 @@ bool optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
         }
     }
 
-    // auto& cfg2 = method.getCFG();
-    // cfg2.dumpGraph("after-removeConstantLoadInLoops.dot", true);
+#ifdef DEBUG_MODE
+    auto& cfg2 = method.getCFG();
+    cfg2.dumpGraph("after-removeConstantLoadInLoops.dot", true);
+#endif
 
     if(hasChanged)
         // combine the newly reordered (and at one place accumulated) loading instructions

--- a/src/optimization/ControlFlow.cpp
+++ b/src/optimization/ControlFlow.cpp
@@ -1480,7 +1480,10 @@ bool optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
             {
                 auto& node1 = inclusionTree.getOrCreateNode(&loop1);
                 auto& node2 = inclusionTree.getOrCreateNode(&loop2);
-                node1.addEdge(&node2, {});
+                if(!node1.isAdjacent(&node2))
+                {
+                    node1.addEdge(&node2, {});
+                }
             }
         }
     }
@@ -1638,7 +1641,7 @@ bool optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
                 for(auto it : insts->second)
                 {
                     auto inst = it.get();
-                    if(processedInsts.find(inst) != processedInsts.end())
+                    if(!it.has() || processedInsts.find(inst) != processedInsts.end())
                         continue;
                     processedInsts.insert(inst);
 
@@ -1656,7 +1659,7 @@ bool optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
                 for(auto it : insts->second)
                 {
                     auto inst = it.get();
-                    if(processedInsts.find(inst) != processedInsts.end())
+                    if(!it.has() || processedInsts.find(inst) != processedInsts.end())
                         continue;
                     processedInsts.insert(inst);
 

--- a/src/optimization/ControlFlow.cpp
+++ b/src/optimization/ControlFlow.cpp
@@ -1319,7 +1319,7 @@ bool optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
 
     auto cfg = method.getCFG().clone();
 #ifdef DEBUG_MODE
-    cfg->dumpGraph("before-removeConstantLoadInLoops.dot", true);
+    cfg->dumpGraph("/tmp/before-removeConstantLoadInLoops.dot", true);
 #endif
 
     // 1. Simplify the CFG to avoid combinatorial explosion. (e.g. testing/test_barrier.cl)
@@ -1442,7 +1442,7 @@ bool optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
     }
 
 #ifdef DEBUG_MODE
-    cfg->dumpGraph("before-removeConstantLoadInLoops-simplified.dot", true);
+    cfg->dumpGraph("/tmp/before-removeConstantLoadInLoops-simplified.dot", true);
 #endif
 
     // 2. Find loops
@@ -1678,7 +1678,7 @@ bool optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
 
 #ifdef DEBUG_MODE
     auto& cfg2 = method.getCFG();
-    cfg2.dumpGraph("after-removeConstantLoadInLoops.dot", true);
+    cfg2.dumpGraph("/tmp/after-removeConstantLoadInLoops.dot", true);
 #endif
 
     if(hasChanged)

--- a/src/optimization/ControlFlow.cpp
+++ b/src/optimization/ControlFlow.cpp
@@ -1365,7 +1365,7 @@ bool optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
             // a.
             bool hasConstantInstruction = false;
             auto block = pair.first;
-            for(auto it = block->begin(); it != block->end(); it = it.nextInBlock())
+            for(auto it = block->walk(); it != block->walkEnd(); it = it.nextInBlock())
             {
                 if(it.has() && it->isConstantInstruction())
                 {
@@ -1634,7 +1634,7 @@ bool optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
             if(targetBlock != nullptr)
             {
                 // insert before 'br' operation
-                auto& targetInst = targetBlock->end().previousInBlock();
+                auto& targetInst = targetBlock->walkEnd().previousInBlock();
                 for(auto it : insts->second)
                 {
                     auto inst = it.get();
@@ -1660,7 +1660,7 @@ bool optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
                         continue;
                     processedInsts.insert(inst);
 
-                    insertedBlock->end().emplace(it.release());
+                    insertedBlock->walkEnd().emplace(it.release());
                     it.erase();
                 }
 

--- a/src/optimization/ControlFlow.cpp
+++ b/src/optimization/ControlFlow.cpp
@@ -1679,6 +1679,8 @@ bool optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
                     insertedBlock->walkEnd().emplace(it.release());
                     it.erase();
                 }
+                // Clear processed instructions
+                insts->second.clear();
 
                 if(headBlock->getLabel()->getLabel()->name == BasicBlock::DEFAULT_BLOCK)
                 {

--- a/src/optimization/ControlFlow.cpp
+++ b/src/optimization/ControlFlow.cpp
@@ -1354,9 +1354,11 @@ bool optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
     }
 
     logging::debug() << "inclusionTree" << logging::endl;
-    for(auto& loop : inclusionTree) {
+    for(auto& loop : inclusionTree)
+    {
         logging::debug() << "  " << loop.first << logging::endl;
-        for(auto& node : loop.second.getNeighbors()) {
+        for(auto& node : loop.second.getNeighbors())
+        {
             logging::debug() << "    " << node.first->key << ": " << node.second.includes << logging::endl;
         }
     }

--- a/src/optimization/ControlFlow.cpp
+++ b/src/optimization/ControlFlow.cpp
@@ -1579,11 +1579,7 @@ bool optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
     for(auto& loop : inclusionTree.getNodes())
     {
         auto& node = inclusionTree.getOrCreateNode(loop.first);
-        auto root = dynamic_cast<LoopInclusionTreeNode*>(node.findRoot({}));
-        if(root == nullptr)
-        {
-            throw CompilationError(CompilationStep::OPTIMIZER, "Cannot downcast to LoopInclusionTreeNode.");
-        }
+        auto root = castToTreeNode(node.findRoot({}));
 
         if(processedNodes.find(root) != processedNodes.end())
             continue;
@@ -1598,12 +1594,8 @@ bool optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
             auto currentNode = que.front();
             que.pop();
 
-            auto targetTreeNode = dynamic_cast<LoopInclusionTreeNode*>(
-                currentNode->findRoot(moveDepth == -1 ? Optional<int>() : Optional<int>(moveDepth - 1)));
-            if(targetTreeNode == nullptr)
-            {
-                throw CompilationError(CompilationStep::OPTIMIZER, "Cannot downcast to LoopInclusionTreeNode.");
-            }
+            auto targetTreeNode =
+                castToTreeNode(currentNode->findRoot(moveDepth == -1 ? Optional<int>() : Optional<int>(moveDepth - 1)));
             auto targetLoop = targetTreeNode->key;
 
             currentNode->forAllOutgoingEdges(

--- a/src/optimization/ControlFlow.cpp
+++ b/src/optimization/ControlFlow.cpp
@@ -1325,7 +1325,8 @@ bool isConstantInstruction(const InstructionWalker& inst)
     }
     auto& args = inst->getArguments();
     return std::all_of(args.begin(), args.end(), [](const Value& arg) { return !arg.isWriteable(); }) &&
-        inst->getOutput().has_value() && !inst->hasSideEffects() && !inst->hasConditionalExecution() && !inst->hasDecoration(InstructionDecorations::PHI_NODE);
+        inst->getOutput().has_value() && !inst->hasSideEffects() && !inst->hasConditionalExecution() &&
+        !inst->hasDecoration(InstructionDecorations::PHI_NODE);
 }
 
 bool optimizations::removeConstantLoadInLoops(const Module& module, Method& method, const Configuration& config)
@@ -1398,8 +1399,7 @@ bool optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
             auto parentNode = &parent;
             int length = parentNode->longestPathLengthToRoot();
 
-            logging::debug() << "  parent node: " << parentNode->dumpLabel() << " length: " << length
-                             << logging::endl;
+            logging::debug() << "  parent node: " << parentNode->dumpLabel() << " length: " << length << logging::endl;
 
             if(length > longestLength)
             {
@@ -1425,7 +1425,8 @@ bool optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
                 return true;
             });
 
-            for (auto &otherNode : nonConnectedEdges) {
+            for(auto& otherNode : nonConnectedEdges)
+            {
                 otherNode->removeAsNeighbor(&currentNode);
                 logging::debug() << "  remove node: " << otherNode->dumpLabel() << logging::endl;
             }
@@ -1507,21 +1508,23 @@ bool optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
                                 auto loopID = reinterpret_cast<LoopInclusionTreeNode*>(targetNode)->key->getID();
 
                                 logging::debug() << "currentLoops(" << currentLoops.size() << ")" << logging::endl;
-                                for (auto &cl : currentLoops) {
+                                for(auto& cl : currentLoops)
+                                {
                                     auto& cn = inclusionTree.getOrCreateNode(&cl);
                                     logging::debug() << "  " << cn.dumpLabel() << " : " << cl.getID() << logging::endl;
                                 }
-                                auto latestLoop = std::find_if(currentLoops.begin(), currentLoops.end(), [&loopID](const ControlFlowLoop& loop) {
-                                    return loop.getID() == loopID;
-                                });
+                                auto latestLoop = std::find_if(currentLoops.begin(), currentLoops.end(),
+                                    [&loopID](const ControlFlowLoop& loop) { return loop.getID() == loopID; });
 
-                                if (latestLoop == currentLoops.end())
-                                    throw CompilationError(CompilationStep::GENERAL, "Cannot find the same loops from latest CFG.");
+                                if(latestLoop == currentLoops.end())
+                                    throw CompilationError(
+                                        CompilationStep::GENERAL, "Cannot find the same loops from latest CFG.");
 
                                 auto targetBlock = latestLoop->findPredecessor();
                                 if(targetBlock != nullptr)
                                 {
-                                    logging::debug() << "  target block: " << targetBlock->key->getLabel()->to_string() << logging::endl;
+                                    logging::debug() << "  target block: " << targetBlock->key->getLabel()->to_string()
+                                                     << logging::endl;
                                     // insert before 'br' operation
                                     auto targetInst = targetBlock->key->walkEnd().previousInBlock();
                                     targetInst.emplace(it.release());
@@ -1556,17 +1559,17 @@ bool optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
                 }
             }
 
-            currentNode->forAllOutgoingEdges([&](const LoopInclusionTreeNode& child, const LoopInclusionTreeEdge&) -> bool {
-                que.push(const_cast<LoopInclusionTreeNode*>(&child));
-                return true;
-            });
+            currentNode->forAllOutgoingEdges(
+                [&](const LoopInclusionTreeNode& child, const LoopInclusionTreeEdge&) -> bool {
+                    que.push(const_cast<LoopInclusionTreeNode*>(&child));
+                    return true;
+                });
         }
     }
 
     if(hasChanged)
         // combine the newly reordered (and at one place accumulated) loading instructions
         combineLoadingConstants(module, method, config);
-
 
     logging::debug() << "finish processing!!!" << logging::endl;
     method.dumpInstructions();

--- a/src/optimization/ControlFlow.cpp
+++ b/src/optimization/ControlFlow.cpp
@@ -1319,7 +1319,7 @@ bool optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
 
     // 1. find loops
     auto& cfg = method.getCFG();
-    cfg.dumpGraph("before-removeConstantLoadInLoops.dot", true);
+    // cfg.dumpGraph("before-removeConstantLoadInLoops.dot", true);
     auto loops = cfg.findLoops(true);
 
     // 2. generate inclusion relation of loops as trees
@@ -1512,8 +1512,8 @@ bool optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
         }
     }
 
-    auto& cfg2 = method.getCFG();
-    cfg2.dumpGraph("after-removeConstantLoadInLoops.dot", true);
+    // auto& cfg2 = method.getCFG();
+    // cfg2.dumpGraph("after-removeConstantLoadInLoops.dot", true);
 
     if(hasChanged)
         // combine the newly reordered (and at one place accumulated) loading instructions

--- a/src/optimization/ControlFlow.cpp
+++ b/src/optimization/ControlFlow.cpp
@@ -1451,7 +1451,11 @@ bool optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
     for(auto& loop : inclusionTree.getNodes())
     {
         auto& node = inclusionTree.getOrCreateNode(loop.first);
-        auto root = reinterpret_cast<LoopInclusionTreeNode*>(node.findRoot({}));
+        auto root = dynamic_cast<LoopInclusionTreeNode*>(node.findRoot({}));
+        if (root == nullptr) {
+            throw CompilationError(
+                    CompilationStep::OPTIMIZER, "Cannot downcast to LoopInclusionTreeNode.");
+        }
         // logging::debug() << "root block : " << root->dumpLabel() << logging::endl;
 
         if(processed.find(root) != processed.end())


### PR DESCRIPTION
- [x] Expand range of instruction (support instructions whose all arguments are immediate value)
  - Please let me know lack of instruction which should be moved.
- [x] Supports `--fmove-constants-depth`
  - Operations which in blocks whose distance from the most inner loop is less than this depth will be moved
- [x] Simplify CFG
  - To avoid combinatorial explosion at removeConstantLoadInLoops. (e.g. testing/test_barrier.cl)