### PR TITLE
Introduces limit of maximum worker threads running in parallel

### DIFF
--- a/src/BackgroundWorker.h
+++ b/src/BackgroundWorker.h
@@ -7,8 +7,10 @@
 #ifndef BACKGROUND_WORKER_H
 #define BACKGROUND_WORKER_H
 
+#include <atomic>
 #include <exception>
 #include <functional>
+#include <list>
 #include <vector>
 
 #ifdef MULTI_THREADED
@@ -47,6 +49,52 @@ namespace vc4c
 #endif
 
         static void waitForAll(std::vector<BackgroundWorker>& worker);
+
+        template <typename T, typename Container = std::list<T>>
+        static void scheduleAll(const Container& c, const std::function<void(const T&)>& func, const std::string name)
+        {
+            auto it = c.begin();
+#ifdef MULTI_THREADED
+            // the maximum number of parallel running workers
+            static constexpr unsigned maxRunning = 16;
+            std::mutex containerGuard;
+            const auto scheduler = [&]() {
+                while(true)
+                {
+                    const T* item = nullptr;
+                    {
+                        std::lock_guard<std::mutex> guard(containerGuard);
+                        if(it == c.end())
+                            return;
+                        item = &(*it);
+                        ++it;
+                    }
+                    func(*item);
+                }
+            };
+#else
+            static constexpr unsigned maxRunning = 1;
+            const auto scheduler = [&]() {
+                while(true)
+                {
+                    if(it == c.end())
+                        return;
+                    const auto& item = *it;
+                    ++it;
+                    func(item);
+                }
+            };
+#endif
+            std::vector<BackgroundWorker> workers;
+            workers.reserve(maxRunning);
+            for(unsigned i = 0; i < std::min(maxRunning, static_cast<unsigned>(c.size())); ++i)
+            {
+                workers.emplace_back(scheduler, name);
+                workers.back().operator()();
+            }
+
+            waitForAll(workers);
+        }
     };
 
 } /* namespace vc4c */


### PR DESCRIPTION
Currently for all parallel steps (normalization, optimization and code generation) one thread is created per kernel in the module. this can lead to a very large memory footprint and to ou-of-memory problems on the Raspberry Pi.

This PR rewrites the background-workers, so a maximum of (currently) 16 workers is run in parallel. If one worker finishes with one kernel function, it processes the next one (thread-pool like) until there are no more kernel functions to be processed.