### PR TITLE
fix: fix not to print misleading warnings

### DIFF
--- a/test/test.cpp
+++ b/test/test.cpp
@@ -6,6 +6,7 @@
 
 #include <cstdlib>
 #include <fstream>
+#include <vector>
 
 #include "cpptest.h"
 #include "cpptest-main.h"
@@ -137,15 +138,19 @@ int main(int argc, char** argv)
     Test::registerSuite(newVectorFunctionsTest, "emulate-vector", "Runs emulation tests for the OpenCL standard-library vector functions");
     Test::registerSuite(newMemoryAccessTest, "emulate-memory", "Runs emulation tests for various functions testing different kinds of memory access");
     Test::registerSuite(newConversionFunctionsTest, "emulate-conversions", "Runs emulation tests for the OpenCL standard-library type conversion functions");
-    
+
+    auto args = std::vector<char*>();
+
     for(auto i = 1; i < argc; ++i)
     { 
-        vc4c::tools::parseConfigurationParameter(config, argv[i]);
+        if (!vc4c::tools::parseConfigurationParameter(config, argv[i]))
+            args.push_back(argv[i]);
+
         //TODO rewrite, actually print same help (parts of it) as VC4C
         if(std::string("--help") == argv[i] || std::string("-h") == argv[i])
             std::cout << "NOTE: This only lists the options for the 'cpptest-lite' test-suite. For more options see 'VC4C --help'!" << std::endl;
     }
 
-    return Test::runSuites(argc, argv);
+    return Test::runSuites(int(args.size()), args.data());
 }
 


### PR DESCRIPTION
This patch surpress warnings of `TestVC4C`.
Currently, `TestVC4C -O3` show some errors as follows:

```
$ ./test/TestVC4C -O3
Unknown parameter: -O3
......
```

Actually, `TestVC4C` accept the optimization option `-O3` successfully.
This message are so misleading.

This patch just filter optimization options, and pass all the rest into testing-framework.