### PR TITLE
Add: Add more files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,29 @@ nbproject/
 # JetBrains
 .idea
 
+# CMake
+CMakeCache.txt
+CMakeFiles
+CPackConfig.cmake
+CPackSourceConfig.cmake
+CTestTestfile.cmake
+cmake_install.cmake
+Makefile
+src/vc4cc-exports.cmake
+
+# libs (why do these exist in root directory?)
+cpptest-lite
+variant
+vc4asm
+cpplog
+
+# build artifacts
+# TODO: dont create artifacts here except build directory
+src/VC4C
+src/libVC4CC.so*
+test/TestVC4C
+tools/qpu_emulator
+
 # Other
 testResult.log
 /valgrind.supp


### PR DESCRIPTION
This patch modifies `.gitignore` to pressure noisy messages `untrucked files` by `git status`.

BTW, I think some configurations are strange. For example, 

- There exist `lib/cpplog`
- And, `cpplog` are located in the root directory
- `build/test/TestVC4C` is not updated by `make`

The upper behaviors are not related this patch, but it makes myself understood that configs are a little bit strange.