### PR TITLE
Change cli interface

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -248,6 +248,7 @@ int main(int argc, char** argv)
         else
         {
             std::cerr << "No output file specified, aborting!" << std::endl;
+            std::cerr << "NOTE: If multiple files are inputed, specifying output file is MUST." << std::endl;
             return 3;
         }
     }


### PR DESCRIPTION
This patch modify the CLI `VC4C` behaviors: allow users to omit specifying an output file when the number of input files are just one.
This behavior is natural compared with other compilers (like `gcc` with `-S` or `-c`).


### before

```
$ VC4C --bin -o ./test.cl.bin test.cl
```

### after

```
$ VC4C --bin test.cl
```

