### PR TITLE
Add `--no-verification-error` and `--verification-error` options

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -208,6 +208,10 @@ namespace vc4c
          * Whether to use CLang opt to apply optimizations like force-vectorization, etc...
          */
         bool useOpt = false;
+        /*
+         * Whether to stop compilation when instruction verification failed
+         */
+        bool stopWhenVerificationFailed = true;
     };
 
     /*

--- a/src/asm/CodeGenerator.cpp
+++ b/src/asm/CodeGenerator.cpp
@@ -253,7 +253,7 @@ void CodeGenerator::toMachineCode(Method& kernel)
     }
 
     Validator v;
-    v.OnMessage = [&instructions](const Message& msg) -> void {
+    v.OnMessage = [&instructions, this](const Message& msg) -> void {
         const auto & validatorMessage = dynamic_cast<const Validator::Message&>(msg);
         if(validatorMessage.Loc >= 0)
         {
@@ -268,8 +268,8 @@ void CodeGenerator::toMachineCode(Method& kernel)
                 logging::error() << "With reference to instruction: " << (*it)->toASMString() << logging::endl;
             }
         }
-
-        throw CompilationError(CompilationStep::VERIFIER, "vc4asm verification error", msg.toString());
+        if (config.stopWhenVerificationFailed)
+            throw CompilationError(CompilationStep::VERIFIER, "vc4asm verification error", msg.toString());
     };
     v.Instructions = &hexData;
     logging::info() << "Validation-output: " << logging::endl;

--- a/src/asm/CodeGenerator.cpp
+++ b/src/asm/CodeGenerator.cpp
@@ -6,13 +6,13 @@
 
 #include "CodeGenerator.h"
 
+#include "../../lib/vc4asm/src/Validator.h"
 #include "../InstructionWalker.h"
 #include "../Module.h"
 #include "../Profiler.h"
 #include "GraphColoring.h"
 #include "KernelInfo.h"
 #include "log.h"
-#include "../../lib/vc4asm/src/Validator.h"
 
 #include <assert.h>
 #include <climits>
@@ -254,7 +254,7 @@ void CodeGenerator::toMachineCode(Method& kernel)
 
     Validator v;
     v.OnMessage = [&instructions, this](const Message& msg) -> void {
-        const auto & validatorMessage = dynamic_cast<const Validator::Message&>(msg);
+        const auto& validatorMessage = dynamic_cast<const Validator::Message&>(msg);
         if(validatorMessage.Loc >= 0)
         {
             auto it = instructions.begin();
@@ -268,7 +268,7 @@ void CodeGenerator::toMachineCode(Method& kernel)
                 logging::error() << "With reference to instruction: " << (*it)->toASMString() << logging::endl;
             }
         }
-        if (config.stopWhenVerificationFailed)
+        if(config.stopWhenVerificationFailed)
             throw CompilationError(CompilationStep::VERIFIER, "vc4asm verification error", msg.toString());
     };
     v.Instructions = &hexData;

--- a/src/asm/CodeGenerator.h
+++ b/src/asm/CodeGenerator.h
@@ -38,6 +38,7 @@ namespace vc4c
             const FastModificationList<std::unique_ptr<qpu_asm::Instruction>>& generateInstructions(Method& method);
 
             std::size_t writeOutput(std::ostream& stream);
+            void toMachineCode(Method& kernel);
 
         private:
             Configuration config;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -72,6 +72,9 @@ static void printHelp()
     std::cout << "\t--spirv\t\t\tExplicitely use the SPIR-V front-end" << std::endl;
     std::cout << "\t--llvm\t\t\tExplicitely use the LLVM-IR front-end" << std::endl;
     std::cout << "\t--disassemble\t\tDisassembles the binary input to either hex or assembler output" << std::endl;
+    std::cout << "\t--verification-error\t\t\tAbort if instruction verification failed" << std::endl;
+    std::cout << "\t--no-verification-error\t\t\tContinue if instruction verification failed" << std::endl;
+
     std::cout << "\tany other option is passed to the pre-compiler" << std::endl;
 }
 

--- a/src/tools/options.cpp
+++ b/src/tools/options.cpp
@@ -122,6 +122,16 @@ bool tools::parseConfigurationParameter(Configuration& config, const std::string
         config.useOpt = false;
         return true;
     }
+    if(arg == "--safe-stop")
+    {
+        config.stopWhenVerificationFailed = true;
+        return true;
+    }
+    if(arg == "--no-safe-stop")
+    {
+        config.stopWhenVerificationFailed = false;
+        return true;
+    }
 
     std::string passName;
     if(arg.find("--fno-") == 0)

--- a/src/tools/options.cpp
+++ b/src/tools/options.cpp
@@ -122,12 +122,12 @@ bool tools::parseConfigurationParameter(Configuration& config, const std::string
         config.useOpt = false;
         return true;
     }
-    if(arg == "--safe-stop")
+    if(arg == "--verification-error")
     {
         config.stopWhenVerificationFailed = true;
         return true;
     }
-    if(arg == "--no-safe-stop")
+    if(arg == "--no-verification-error")
     {
         config.stopWhenVerificationFailed = false;
         return true;


### PR DESCRIPTION
~~This patch append `--no-safe-stop` and `--safe-stop` options to stop or continue when the instruction verification fail.~~
This patch append `--no-verification-error` and `--verification-error` options to stop or continue when the instruction verification fail.


When the verification failed, it is a little bit trouble to see failed instructions directly (because it aborts immediately). With `--no-verification-error`, compilation itself continue even in such situations.

I want to apply it for debugging debugging register allocator.