### PR TITLE
Fix test_prime

### DIFF
--- a/example/test_prime.cl
+++ b/example/test_prime.cl
@@ -6,7 +6,7 @@ __kernel void test_prime(const int maybePrime, __global bool* out)
 	int root = ceil(tmp);
 	for(int i = 2; i <= root; i++)
 	{
-		if(root % i == 0)
+		if(maybePrime % i == 0)
 		{
 			*out = false;
 			return;


### PR DESCRIPTION
In this test case, `i` equals `root` by counting up, so `root % i == 0` is evaluated true and `out` equals false every time.