### PR TITLE
Fix not to use reference

### DIFF
--- a/src/optimization/ControlFlow.cpp
+++ b/src/optimization/ControlFlow.cpp
@@ -1642,7 +1642,7 @@ bool optimizations::removeConstantLoadInLoops(const Module& module, Method& meth
             if(targetBlock != nullptr)
             {
                 // insert before 'br' operation
-                auto& targetInst = targetBlock->walkEnd().previousInBlock();
+                auto targetInst = targetBlock->walkEnd().previousInBlock();
                 for(auto it : insts->second)
                 {
                     auto inst = it.get();


### PR DESCRIPTION
If `targetInst` is a reference, an error occurs(`Background worker threw error: Label/Register Mapping: Local is being read, but first and last occurrence are the same: i32 %immediate.54`). It fixes it.