### PR TITLE
Build instructions and initialization fix (tests)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -45,5 +45,3 @@ Run `cpack -G DEB` to create a debian package.
 If the [VC4CLStdLib](https://github.com/doe300/VC4CLStdLib) is updated, the LLVM pre-compiled header (PCH) needs to be rebuilt. For this to happen, simply delete the file `VC4CLStdLib.h.pch` (located in the source/installation directory of the VC4CLStdLib project, depending on whether it was installed) and rebuild the VC4C compiler (or just the `vc4cl-stdlib` target).
 
 When `BUILD_TESTING` is on, some of the files (`TestConversionFunctions.cpp.o`) have to be compiled in one thread (`make -j 1`).
-
-During compilation on GCC 8.3.0, pass extra `-DCMAKE_CXX_FLAGS="-Werror=maybe-uninitialized"`.

--- a/Readme.md
+++ b/Readme.md
@@ -43,3 +43,7 @@ Run `cpack -G DEB` to create a debian package.
 ## Known Issues
 
 If the [VC4CLStdLib](https://github.com/doe300/VC4CLStdLib) is updated, the LLVM pre-compiled header (PCH) needs to be rebuilt. For this to happen, simply delete the file `VC4CLStdLib.h.pch` (located in the source/installation directory of the VC4CLStdLib project, depending on whether it was installed) and rebuild the VC4C compiler (or just the `vc4cl-stdlib` target).
+
+When `BUILD_TESTING` is on, some of the files (`TestConversionFunctions.cpp.o`) have to be compiled in one thread (`make -j 1`).
+
+During compilation on GCC 8.3.0, pass extra `-DCMAKE_CXX_FLAGS="-Werror=maybe-uninitialized"`.

--- a/test/emulation_helper.h
+++ b/test/emulation_helper.h
@@ -426,6 +426,7 @@ std::array<Result, VectorWidth * LocalSize * NumGroups> runEmulation(std::string
         throw vc4c::CompilationError(vc4c::CompilationStep::GENERAL, "Kernel execution failed");
 
     std::array<Result, VectorWidth * LocalSize * NumGroups> output;
+    output.fill(0);
     copyConvert<VectorWidth * LocalSize * NumGroups>(result.results[0].second.value(), output);
     return output;
 }

--- a/test/emulation_helper.h
+++ b/test/emulation_helper.h
@@ -425,8 +425,7 @@ std::array<Result, VectorWidth * LocalSize * NumGroups> runEmulation(std::string
     if(!result.executionSuccessful)
         throw vc4c::CompilationError(vc4c::CompilationStep::GENERAL, "Kernel execution failed");
 
-    std::array<Result, VectorWidth * LocalSize * NumGroups> output;
-    output.fill(0);
+    std::array<Result, VectorWidth * LocalSize * NumGroups> output {0};
     copyConvert<VectorWidth * LocalSize * NumGroups>(result.results[0].second.value(), output);
     return output;
 }


### PR DESCRIPTION
Added a tip for compilation in Readme.
GCC 8.3 hangs on `TestConversionFunctions` when compiled with more than one thread. The compilation can be simply interrupted when this file is being processed and continued with `make -j 1`.

`emulator_helper.h` throws compilation warning/error. However, setting the suggested flag doesn't work thus I added `output.fill(0);`. Apparently this "initializes".