### PR TITLE
Update spirv-headers.cmake

### DIFF
--- a/cmake/spirv-headers.cmake
+++ b/cmake/spirv-headers.cmake
@@ -5,7 +5,7 @@ if(DEPENDENCIES_USE_FETCH_CONTENT)
 	include(FetchContent)
 	set(SPIRV_HEADERS_SKIP_INSTALL ON CACHE INTERNAL "Disable installation of SPIR-V headers")
 	set(SPIRV_HEADERS_SKIP_EXAMPLES ON CACHE INTERNAL "Disable building of SPIR-V header examples")
-	FetchContent_Declare(SPIRV-Headers GIT_REPOSITORY https://github.com/KhronosGroup/SPIRV-Headers.git)
+	FetchContent_Declare(SPIRV-Headers GIT_REPOSITORY https://github.com/KhronosGroup/SPIRV-Headers.git GIT_TAG main)
 	FetchContent_MakeAvailable(SPIRV-Headers)
 	FetchContent_GetProperties(SPIRV-Headers SOURCE_DIR SPIRV_HEADERS_SOURCE_DIR)
 
@@ -18,6 +18,7 @@ else()
 	ExternalProject_Add(SPIRV-Headers-project
 		PREFIX 				${CMAKE_BINARY_DIR}/spirv-headers
 		GIT_REPOSITORY 		https://github.com/KhronosGroup/SPIRV-Headers.git
+		GIT_TAG                 main
 		UPDATE_COMMAND 		git pull -f https://github.com/KhronosGroup/SPIRV-Headers.git
 		STEP_TARGETS 		build
 		EXCLUDE_FROM_ALL	TRUE


### PR DESCRIPTION
fix: update spirv-headers.cmake after SPIRV-Headers master branch was renamed to main